### PR TITLE
Tweak static pages layout

### DIFF
--- a/website/pages/en/404.js
+++ b/website/pages/en/404.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const React = require("react");
+
+const Index = () => (
+  <div className="docMainWrapper wrapper">
+    <div className="container docsNavContainer" id="docsNav" />
+    <div className="container mainContainer">
+      <div className="wrapper">
+        <div className="post">
+          <header className="postHeader">
+            <h1 className="postHeaderTitle">
+              Requested page could not be found.
+            </h1>
+          </header>
+          <article>
+            <a href="/docs/">Return to documentation.</a>
+          </article>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+Index.title = "Page not found";
+
+module.exports = Index;

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -8,8 +8,22 @@
 const React = require("react");
 
 const Index = () => (
-  <div>
-    <a href="/docs/">Go to docs...</a>
+  <div className="docMainWrapper wrapper">
+    <div className="container docsNavContainer" id="docsNav" />
+    <div className="container mainContainer">
+      <div className="wrapper">
+        <div className="post">
+          <header className="postHeader">
+            <h1 className="postHeaderTitle">
+              Welcome to the Saleor documentation!
+            </h1>
+          </header>
+          <article>
+            <a href="/docs/">Go to documentation contents.</a>
+          </article>
+        </div>
+      </div>
+    </div>
   </div>
 );
 

--- a/website/static/css/layout.css
+++ b/website/static/css/layout.css
@@ -169,6 +169,10 @@
     background: #f6fafa;
   }
 
+    .docsNavContainer:empty {
+      background: none;
+    }
+
   .toc {
     padding-top: 10px;
   }


### PR DESCRIPTION
This PR adds some styling to static pages, so they fit visually to the rest of the docs:

<img width="1680" alt="Zrzut ekranu 2019-08-8 o 15 12 13" src="https://user-images.githubusercontent.com/750553/62706036-f2e59d00-b9ee-11e9-9a2c-68e31e0b9bb3.png">
