### PR TITLE
Add changes in dev docs made after initial devdocs sync

### DIFF
--- a/docs/customization/extensions.md
+++ b/docs/customization/extensions.md
@@ -1,0 +1,110 @@
+---
+id: extensions
+title: Extensions
+---
+
+Saleor has implemented extensions architecture. It includes hooks for most basic operations like calculation of prices in the checkout or calling some actions when an order has been created.
+
+
+## Plugin
+
+Saleor has some plugins implemented by default. These plugins are located in `saleor.core.extensions.plugins`. The ExtensionManager needs to receive a list of enabled plugins. It can be done by including the Python plugin path in the `settings.PLUGINS` list.
+
+
+### Writing Your Own Plugin
+
+A custom plugin has to inherit from the `BasePlugin` class. It should overwrite base methods. The plugin needs to be added to the `settings.PLUGINS` Your own plugin can be written as a class which has callable instances, like this:
+
+```python
+custom/plugin.py
+
+from django.conf import settings
+from urllib.parse import urljoin
+
+from ...base_plugin import BasePlugin
+from .tasks import api_post_request_task
+
+class CustomPlugin(BasePlugin):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled = bool(settings.CUSTOM_PLUGIN_KEYS)
+
+
+    def postprocess_order_creation(self, order: "Order", previous_value: Any):
+        if not self._enabled:
+            return
+        data = {}
+
+        transaction_url = urljoin(settings.CUSTOM_API_URL, "transactions/createoradjust")
+        api_post_request_task.delay(transaction_url, data)
+```
+
+> **Note**
+>
+> There is no need to implement all base methods. `ExtensionManager` will use default values for methods that are not implemented.
+
+
+### Activating Plugin
+
+To activate the plugin, add it to the `PLUGINS` list in your Django settings:
+
+```python
+# settings.py
+
+PLUGINS = ["saleor.core.extensions.plugins.custom.CustomPlugin", ]
+```
+
+
+## `ExtensionsManager`
+
+`ExtensionsManager` is located in the `saleor.core.extensions.base_plugin`. It is a class responsible for handling all declared plugins and serving a response from them. It serves a default response in case of a non-declared plugin. There is a possibility to overwrite an `ExtensionsManager` class by implementing it on its own. Saleor will discover the manager class by taking the declared path from `settings.EXTENSIONS_MANAGER`. Each Django request object has its own manager included as the `extensions` field. It is attached in the Saleor middleware.
+
+
+## BasePlugin
+
+`BasePlugin` is located in the `saleor.core.extensions.base_plugin`. It is an abstract class for storing all methods available for any plugin. All methods take the `previous_value` parameter. This contains a value calculated by the previous plugin in the queue. If the plugin is first in line, it will use the default value calculated by the manager.
+
+
+## Celery Tasks
+
+Some plugin operations should be done asynchronously. If Saleor has Celery enabled, it will discover all tasks declared in tasks.py in the plugin directories.
+
+
+### `plugin.py`
+
+```python
+def postprocess_order_creation(self, order: "Order", previous_value: Any):
+    if not self._enabled:
+        return
+    data = {}
+    transaction_url = urljoin(get_api_url(), "transactions/createoradjust")
+
+    api_post_request_task.delay(transaction_url, data)
+```
+
+
+### `tasks.py`
+
+```python
+import json
+from celery import shared_task
+from typing import Any, Dict
+
+import requests
+from requests.auth import HTTPBasicAuth
+from django.conf import settings
+
+
+@shared_task
+def api_post_request(
+    url: str,
+    data: Dict[str, Any],
+):
+    try:
+        username = "username"
+        password = "password"
+        auth = HTTPBasicAuth(username, password)
+        requests.post(url, auth=auth, data=json.dumps(data), timeout=settings.TIMEOUT)
+    except requests.exceptions.RequestException:
+        return
+```

--- a/docs/customization/intro.md
+++ b/docs/customization/intro.md
@@ -16,14 +16,15 @@ sidebar_label: Introduction
 
 [card-grid]
 [**Working with Python Code**](customization/backend.md)
+[**Creating extensions**](customization/extensions.md)
+[/card-grid]
+
+[card-grid]
 [**Internationalization**](customization/i18n.md)
-[/card-grid]
-
-[card-grid]
 [**Running Tests**](customization/running-tests.md)
-[**Continuous Integration**](customization/continuous-integration.md)
 [/card-grid]
 
 [card-grid]
+[**Continuous Integration**](customization/continuous-integration.md)
 [**Running with PyPy 3.5**](customization/pypy.md)
 [/card-grid]

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -96,7 +96,7 @@ Controls [Django’s secret key](https://docs.djangoproject.com/en/2.1/ref/setti
 
 ### `SENTRY_DSN`
 
-Sentry’s [Data Source Name](https://docs.sentry.io/quickstart/#about-the-dsn). Disabled by default, allows to enable integration with Sentry (see [Error tracking with Sentry](integrations/sentry.md) for details).
+Sentry’s [Data Source Name](https://docs.sentry.io/error-reporting/configuration/?platform=python#dsn). Disabled by default, allows to enable integration with Sentry (see [Error tracking with Sentry](integrations/sentry.md) for details).
 
 
 ### `MAX_CART_LINE_QUANTITY`

--- a/docs/integrations/sentry.md
+++ b/docs/integrations/sentry.md
@@ -9,4 +9,4 @@ To enable basic error reporting you have to export an environment variable:
 
 - `SENTRY_DSN` - Sentry Data Source Name.
 
-If you need to customize the service, please go to the [official Sentry’s documentation for Django](https://docs.sentry.io/clients/python/integrations/django/) for more details.
+If you need to customize the service, please go to the [official Sentry’s documentation for Django](https://docs.sentry.io/platforms/python/django/) for more details.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -28,6 +28,7 @@
           "customization/emails",
           "customization/frontend",
           "customization/backend",
+          "customization/extensions",
           "customization/i18n",
           "customization/running-tests",
           "customization/continuous-integration",


### PR DESCRIPTION
Old docs had Extensions and Sentry pages updated sometime after I've moved all dev docs to Docusaurus. This PR re-adds those to new docs.