### PR TITLE
Enable search

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -26,6 +26,11 @@ const siteConfig = {
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'JoelMarcey'
 
+  algolia: {
+    apiKey: "33843c1b27663cc760ddc60811ba51d7",
+    indexName: "saleor"
+  },
+
   // Disable showing the title in the header next to the header icon.
   disableHeaderTitle: true,
 

--- a/website/static/css/layout.css
+++ b/website/static/css/layout.css
@@ -176,6 +176,25 @@
   .toc {
     padding-top: 10px;
   }
+
+  .navigationSlider {
+    position: static;
+    height: auto;
+    margin: 0;
+    margin-left: 48px;
+    margin-top: 32px;
+  }
+
+    .navigationSlider .nav-site {
+      margin: auto;
+      max-width: 700px;
+    }
+
+  .navSearchWrapper {
+    display: block;
+    position: static !important;
+    padding: 0;
+  }
 }
 
 /* Page nav */


### PR DESCRIPTION
This PR enables search on the docs:

<img width="1010" alt="Zrzut ekranu 2019-08-19 o 14 35 18" src="https://user-images.githubusercontent.com/750553/63265750-9a37bf00-c28e-11e9-83fc-ed294cd6159c.png">

Currently search bar is always aligned to the sidebar. If we want to align it to the content column, that would take some extra CSS-fu, so its up for @maarcingebala and @pwgryglak if we want to do it.