### PR TITLE
Fix Algolia's branding not displaying correctly on search results

### DIFF
--- a/website/static/css/layout.css
+++ b/website/static/css/layout.css
@@ -141,7 +141,7 @@
     padding-left: 0;
   }
 
-  .fixedHeaderContainer header a:first-child {
+  .fixedHeaderContainer header>a:first-child {
     display: block;
     width: 363px;
     padding: 30px 0;
@@ -150,11 +150,11 @@
     height: auto;
   }
 
-  .fixedHeaderContainer header a:first-child img {
+  .fixedHeaderContainer header>a:first-child img {
     height: 40px;
   }
 
-  .fixedHeaderContainer header a:nth-child(2) {
+  .fixedHeaderContainer header>a:nth-child(2) {
     display: block;
     position: absolute;
     top: 32px;


### PR DESCRIPTION
Some of our CSS selectors ended overzelous and in result has overrided the Algolia's branding in search results block. This PR fixes this.