### PR TITLE
Add API reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,32735 @@
+---
+id: api-reference
+title: API Reference
+---
+
+This document describes all queries, mutations and types available in Saleor GraphQL API.
+
+<!-- START graphql-markdown -->
+
+<details>
+  <summary><strong>Table of Contents</strong></summary>
+
+  * [Query](#query)
+  * [Mutation](#mutation)
+  * [Objects](#objects)
+    * [AccountAddressCreate](#accountaddresscreate)
+    * [AccountAddressDelete](#accountaddressdelete)
+    * [AccountAddressUpdate](#accountaddressupdate)
+    * [AccountDelete](#accountdelete)
+    * [AccountError](#accounterror)
+    * [AccountRegister](#accountregister)
+    * [AccountRequestDeletion](#accountrequestdeletion)
+    * [AccountSetDefaultAddress](#accountsetdefaultaddress)
+    * [AccountUpdate](#accountupdate)
+    * [Address](#address)
+    * [AddressCreate](#addresscreate)
+    * [AddressDelete](#addressdelete)
+    * [AddressSetDefault](#addresssetdefault)
+    * [AddressUpdate](#addressupdate)
+    * [AddressValidationData](#addressvalidationdata)
+    * [AssignNavigation](#assignnavigation)
+    * [Attribute](#attribute)
+    * [AttributeAssign](#attributeassign)
+    * [AttributeBulkDelete](#attributebulkdelete)
+    * [AttributeClearMeta](#attributeclearmeta)
+    * [AttributeClearPrivateMeta](#attributeclearprivatemeta)
+    * [AttributeCountableConnection](#attributecountableconnection)
+    * [AttributeCountableEdge](#attributecountableedge)
+    * [AttributeCreate](#attributecreate)
+    * [AttributeDelete](#attributedelete)
+    * [AttributeReorderValues](#attributereordervalues)
+    * [AttributeTranslate](#attributetranslate)
+    * [AttributeTranslation](#attributetranslation)
+    * [AttributeUnassign](#attributeunassign)
+    * [AttributeUpdate](#attributeupdate)
+    * [AttributeUpdateMeta](#attributeupdatemeta)
+    * [AttributeUpdatePrivateMeta](#attributeupdateprivatemeta)
+    * [AttributeValue](#attributevalue)
+    * [AttributeValueBulkDelete](#attributevaluebulkdelete)
+    * [AttributeValueCreate](#attributevaluecreate)
+    * [AttributeValueDelete](#attributevaluedelete)
+    * [AttributeValueTranslate](#attributevaluetranslate)
+    * [AttributeValueTranslation](#attributevaluetranslation)
+    * [AttributeValueUpdate](#attributevalueupdate)
+    * [AuthorizationKey](#authorizationkey)
+    * [AuthorizationKeyAdd](#authorizationkeyadd)
+    * [AuthorizationKeyDelete](#authorizationkeydelete)
+    * [Category](#category)
+    * [CategoryBulkDelete](#categorybulkdelete)
+    * [CategoryClearMeta](#categoryclearmeta)
+    * [CategoryClearPrivateMeta](#categoryclearprivatemeta)
+    * [CategoryCountableConnection](#categorycountableconnection)
+    * [CategoryCountableEdge](#categorycountableedge)
+    * [CategoryCreate](#categorycreate)
+    * [CategoryDelete](#categorydelete)
+    * [CategoryTranslate](#categorytranslate)
+    * [CategoryTranslation](#categorytranslation)
+    * [CategoryUpdate](#categoryupdate)
+    * [CategoryUpdateMeta](#categoryupdatemeta)
+    * [CategoryUpdatePrivateMeta](#categoryupdateprivatemeta)
+    * [Checkout](#checkout)
+    * [CheckoutAddPromoCode](#checkoutaddpromocode)
+    * [CheckoutBillingAddressUpdate](#checkoutbillingaddressupdate)
+    * [CheckoutClearStoredMeta](#checkoutclearstoredmeta)
+    * [CheckoutClearStoredPrivateMeta](#checkoutclearstoredprivatemeta)
+    * [CheckoutComplete](#checkoutcomplete)
+    * [CheckoutCountableConnection](#checkoutcountableconnection)
+    * [CheckoutCountableEdge](#checkoutcountableedge)
+    * [CheckoutCreate](#checkoutcreate)
+    * [CheckoutCustomerAttach](#checkoutcustomerattach)
+    * [CheckoutCustomerDetach](#checkoutcustomerdetach)
+    * [CheckoutEmailUpdate](#checkoutemailupdate)
+    * [CheckoutError](#checkouterror)
+    * [CheckoutLine](#checkoutline)
+    * [CheckoutLineCountableConnection](#checkoutlinecountableconnection)
+    * [CheckoutLineCountableEdge](#checkoutlinecountableedge)
+    * [CheckoutLineDelete](#checkoutlinedelete)
+    * [CheckoutLinesAdd](#checkoutlinesadd)
+    * [CheckoutLinesUpdate](#checkoutlinesupdate)
+    * [CheckoutPaymentCreate](#checkoutpaymentcreate)
+    * [CheckoutRemovePromoCode](#checkoutremovepromocode)
+    * [CheckoutShippingAddressUpdate](#checkoutshippingaddressupdate)
+    * [CheckoutShippingMethodUpdate](#checkoutshippingmethodupdate)
+    * [CheckoutUpdateMeta](#checkoutupdatemeta)
+    * [CheckoutUpdatePrivateMeta](#checkoutupdateprivatemeta)
+    * [CheckoutUpdateVoucher](#checkoutupdatevoucher)
+    * [ChoiceValue](#choicevalue)
+    * [Collection](#collection)
+    * [CollectionAddProducts](#collectionaddproducts)
+    * [CollectionBulkDelete](#collectionbulkdelete)
+    * [CollectionBulkPublish](#collectionbulkpublish)
+    * [CollectionClearMeta](#collectionclearmeta)
+    * [CollectionClearPrivateMeta](#collectionclearprivatemeta)
+    * [CollectionCountableConnection](#collectioncountableconnection)
+    * [CollectionCountableEdge](#collectioncountableedge)
+    * [CollectionCreate](#collectioncreate)
+    * [CollectionDelete](#collectiondelete)
+    * [CollectionRemoveProducts](#collectionremoveproducts)
+    * [CollectionReorderProducts](#collectionreorderproducts)
+    * [CollectionTranslate](#collectiontranslate)
+    * [CollectionTranslation](#collectiontranslation)
+    * [CollectionUpdate](#collectionupdate)
+    * [CollectionUpdateMeta](#collectionupdatemeta)
+    * [CollectionUpdatePrivateMeta](#collectionupdateprivatemeta)
+    * [ConfigurationItem](#configurationitem)
+    * [CountryDisplay](#countrydisplay)
+    * [CreateToken](#createtoken)
+    * [CreditCard](#creditcard)
+    * [CustomerAddressCreate](#customeraddresscreate)
+    * [CustomerBulkDelete](#customerbulkdelete)
+    * [CustomerCreate](#customercreate)
+    * [CustomerDelete](#customerdelete)
+    * [CustomerEvent](#customerevent)
+    * [CustomerPasswordReset](#customerpasswordreset)
+    * [CustomerRegister](#customerregister)
+    * [CustomerSetDefaultAddress](#customersetdefaultaddress)
+    * [CustomerUpdate](#customerupdate)
+    * [DigitalContent](#digitalcontent)
+    * [DigitalContentCountableConnection](#digitalcontentcountableconnection)
+    * [DigitalContentCountableEdge](#digitalcontentcountableedge)
+    * [DigitalContentCreate](#digitalcontentcreate)
+    * [DigitalContentDelete](#digitalcontentdelete)
+    * [DigitalContentUpdate](#digitalcontentupdate)
+    * [DigitalContentUrl](#digitalcontenturl)
+    * [DigitalContentUrlCreate](#digitalcontenturlcreate)
+    * [Domain](#domain)
+    * [DraftOrderBulkDelete](#draftorderbulkdelete)
+    * [DraftOrderComplete](#draftordercomplete)
+    * [DraftOrderCreate](#draftordercreate)
+    * [DraftOrderDelete](#draftorderdelete)
+    * [DraftOrderLineDelete](#draftorderlinedelete)
+    * [DraftOrderLineUpdate](#draftorderlineupdate)
+    * [DraftOrderLinesBulkDelete](#draftorderlinesbulkdelete)
+    * [DraftOrderLinesCreate](#draftorderlinescreate)
+    * [DraftOrderUpdate](#draftorderupdate)
+    * [Error](#error)
+    * [ExtensionsError](#extensionserror)
+    * [Fulfillment](#fulfillment)
+    * [FulfillmentCancel](#fulfillmentcancel)
+    * [FulfillmentCreate](#fulfillmentcreate)
+    * [FulfillmentLine](#fulfillmentline)
+    * [FulfillmentUpdateTracking](#fulfillmentupdatetracking)
+    * [Geolocalization](#geolocalization)
+    * [GiftCard](#giftcard)
+    * [GiftCardActivate](#giftcardactivate)
+    * [GiftCardCountableConnection](#giftcardcountableconnection)
+    * [GiftCardCountableEdge](#giftcardcountableedge)
+    * [GiftCardCreate](#giftcardcreate)
+    * [GiftCardDeactivate](#giftcarddeactivate)
+    * [GiftCardError](#giftcarderror)
+    * [GiftCardUpdate](#giftcardupdate)
+    * [HomepageCollectionUpdate](#homepagecollectionupdate)
+    * [Image](#image)
+    * [LanguageDisplay](#languagedisplay)
+    * [LoggedUserUpdate](#loggeduserupdate)
+    * [Margin](#margin)
+    * [Menu](#menu)
+    * [MenuBulkDelete](#menubulkdelete)
+    * [MenuCountableConnection](#menucountableconnection)
+    * [MenuCountableEdge](#menucountableedge)
+    * [MenuCreate](#menucreate)
+    * [MenuDelete](#menudelete)
+    * [MenuError](#menuerror)
+    * [MenuItem](#menuitem)
+    * [MenuItemBulkDelete](#menuitembulkdelete)
+    * [MenuItemCountableConnection](#menuitemcountableconnection)
+    * [MenuItemCountableEdge](#menuitemcountableedge)
+    * [MenuItemCreate](#menuitemcreate)
+    * [MenuItemDelete](#menuitemdelete)
+    * [MenuItemMove](#menuitemmove)
+    * [MenuItemTranslate](#menuitemtranslate)
+    * [MenuItemTranslation](#menuitemtranslation)
+    * [MenuItemUpdate](#menuitemupdate)
+    * [MenuUpdate](#menuupdate)
+    * [MetaClientStore](#metaclientstore)
+    * [MetaItem](#metaitem)
+    * [MetaStore](#metastore)
+    * [Money](#money)
+    * [MoneyRange](#moneyrange)
+    * [Navigation](#navigation)
+    * [Order](#order)
+    * [OrderAddNote](#orderaddnote)
+    * [OrderBulkCancel](#orderbulkcancel)
+    * [OrderCancel](#ordercancel)
+    * [OrderCapture](#ordercapture)
+    * [OrderCountableConnection](#ordercountableconnection)
+    * [OrderCountableEdge](#ordercountableedge)
+    * [OrderError](#ordererror)
+    * [OrderEvent](#orderevent)
+    * [OrderEventCountableConnection](#ordereventcountableconnection)
+    * [OrderEventCountableEdge](#ordereventcountableedge)
+    * [OrderEventOrderLineObject](#ordereventorderlineobject)
+    * [OrderLine](#orderline)
+    * [OrderMarkAsPaid](#ordermarkaspaid)
+    * [OrderRefund](#orderrefund)
+    * [OrderUpdate](#orderupdate)
+    * [OrderUpdateShipping](#orderupdateshipping)
+    * [OrderVoid](#ordervoid)
+    * [Page](#page)
+    * [PageBulkDelete](#pagebulkdelete)
+    * [PageBulkPublish](#pagebulkpublish)
+    * [PageCountableConnection](#pagecountableconnection)
+    * [PageCountableEdge](#pagecountableedge)
+    * [PageCreate](#pagecreate)
+    * [PageDelete](#pagedelete)
+    * [PageInfo](#pageinfo)
+    * [PageTranslate](#pagetranslate)
+    * [PageTranslation](#pagetranslation)
+    * [PageUpdate](#pageupdate)
+    * [PasswordChange](#passwordchange)
+    * [PasswordReset](#passwordreset)
+    * [Payment](#payment)
+    * [PaymentCapture](#paymentcapture)
+    * [PaymentCountableConnection](#paymentcountableconnection)
+    * [PaymentCountableEdge](#paymentcountableedge)
+    * [PaymentError](#paymenterror)
+    * [PaymentRefund](#paymentrefund)
+    * [PaymentSecureConfirm](#paymentsecureconfirm)
+    * [PaymentSource](#paymentsource)
+    * [PaymentVoid](#paymentvoid)
+    * [PermissionDisplay](#permissiondisplay)
+    * [Plugin](#plugin)
+    * [PluginCountableConnection](#plugincountableconnection)
+    * [PluginCountableEdge](#plugincountableedge)
+    * [PluginUpdate](#pluginupdate)
+    * [Product](#product)
+    * [ProductBulkDelete](#productbulkdelete)
+    * [ProductBulkPublish](#productbulkpublish)
+    * [ProductClearMeta](#productclearmeta)
+    * [ProductClearPrivateMeta](#productclearprivatemeta)
+    * [ProductCountableConnection](#productcountableconnection)
+    * [ProductCountableEdge](#productcountableedge)
+    * [ProductCreate](#productcreate)
+    * [ProductDelete](#productdelete)
+    * [ProductError](#producterror)
+    * [ProductImage](#productimage)
+    * [ProductImageBulkDelete](#productimagebulkdelete)
+    * [ProductImageCreate](#productimagecreate)
+    * [ProductImageDelete](#productimagedelete)
+    * [ProductImageReorder](#productimagereorder)
+    * [ProductImageUpdate](#productimageupdate)
+    * [ProductPricingInfo](#productpricinginfo)
+    * [ProductTranslate](#producttranslate)
+    * [ProductTranslation](#producttranslation)
+    * [ProductType](#producttype)
+    * [ProductTypeBulkDelete](#producttypebulkdelete)
+    * [ProductTypeClearMeta](#producttypeclearmeta)
+    * [ProductTypeClearPrivateMeta](#producttypeclearprivatemeta)
+    * [ProductTypeCountableConnection](#producttypecountableconnection)
+    * [ProductTypeCountableEdge](#producttypecountableedge)
+    * [ProductTypeCreate](#producttypecreate)
+    * [ProductTypeDelete](#producttypedelete)
+    * [ProductTypeReorderAttributes](#producttypereorderattributes)
+    * [ProductTypeUpdate](#producttypeupdate)
+    * [ProductTypeUpdateMeta](#producttypeupdatemeta)
+    * [ProductTypeUpdatePrivateMeta](#producttypeupdateprivatemeta)
+    * [ProductUpdate](#productupdate)
+    * [ProductUpdateMeta](#productupdatemeta)
+    * [ProductUpdatePrivateMeta](#productupdateprivatemeta)
+    * [ProductVariant](#productvariant)
+    * [ProductVariantBulkDelete](#productvariantbulkdelete)
+    * [ProductVariantClearMeta](#productvariantclearmeta)
+    * [ProductVariantClearPrivateMeta](#productvariantclearprivatemeta)
+    * [ProductVariantCountableConnection](#productvariantcountableconnection)
+    * [ProductVariantCountableEdge](#productvariantcountableedge)
+    * [ProductVariantCreate](#productvariantcreate)
+    * [ProductVariantDelete](#productvariantdelete)
+    * [ProductVariantTranslate](#productvarianttranslate)
+    * [ProductVariantTranslation](#productvarianttranslation)
+    * [ProductVariantUpdate](#productvariantupdate)
+    * [ProductVariantUpdateMeta](#productvariantupdatemeta)
+    * [ProductVariantUpdatePrivateMeta](#productvariantupdateprivatemeta)
+    * [ReducedRate](#reducedrate)
+    * [Refresh](#refresh)
+    * [RequestPasswordReset](#requestpasswordreset)
+    * [Sale](#sale)
+    * [SaleAddCatalogues](#saleaddcatalogues)
+    * [SaleBulkDelete](#salebulkdelete)
+    * [SaleCountableConnection](#salecountableconnection)
+    * [SaleCountableEdge](#salecountableedge)
+    * [SaleCreate](#salecreate)
+    * [SaleDelete](#saledelete)
+    * [SaleRemoveCatalogues](#saleremovecatalogues)
+    * [SaleTranslate](#saletranslate)
+    * [SaleTranslation](#saletranslation)
+    * [SaleUpdate](#saleupdate)
+    * [SelectedAttribute](#selectedattribute)
+    * [ServiceAccount](#serviceaccount)
+    * [ServiceAccountClearStoredPrivateMeta](#serviceaccountclearstoredprivatemeta)
+    * [ServiceAccountCountableConnection](#serviceaccountcountableconnection)
+    * [ServiceAccountCountableEdge](#serviceaccountcountableedge)
+    * [ServiceAccountCreate](#serviceaccountcreate)
+    * [ServiceAccountDelete](#serviceaccountdelete)
+    * [ServiceAccountUpdate](#serviceaccountupdate)
+    * [ServiceAccountUpdatePrivateMeta](#serviceaccountupdateprivatemeta)
+    * [SetPassword](#setpassword)
+    * [ShippingError](#shippingerror)
+    * [ShippingMethod](#shippingmethod)
+    * [ShippingMethodTranslation](#shippingmethodtranslation)
+    * [ShippingPriceBulkDelete](#shippingpricebulkdelete)
+    * [ShippingPriceCreate](#shippingpricecreate)
+    * [ShippingPriceDelete](#shippingpricedelete)
+    * [ShippingPriceTranslate](#shippingpricetranslate)
+    * [ShippingPriceUpdate](#shippingpriceupdate)
+    * [ShippingZone](#shippingzone)
+    * [ShippingZoneBulkDelete](#shippingzonebulkdelete)
+    * [ShippingZoneCountableConnection](#shippingzonecountableconnection)
+    * [ShippingZoneCountableEdge](#shippingzonecountableedge)
+    * [ShippingZoneCreate](#shippingzonecreate)
+    * [ShippingZoneDelete](#shippingzonedelete)
+    * [ShippingZoneUpdate](#shippingzoneupdate)
+    * [Shop](#shop)
+    * [ShopAddressUpdate](#shopaddressupdate)
+    * [ShopDomainUpdate](#shopdomainupdate)
+    * [ShopError](#shoperror)
+    * [ShopFetchTaxRates](#shopfetchtaxrates)
+    * [ShopSettingsTranslate](#shopsettingstranslate)
+    * [ShopSettingsUpdate](#shopsettingsupdate)
+    * [ShopTranslation](#shoptranslation)
+    * [StaffBulkDelete](#staffbulkdelete)
+    * [StaffCreate](#staffcreate)
+    * [StaffDelete](#staffdelete)
+    * [StaffUpdate](#staffupdate)
+    * [TaxType](#taxtype)
+    * [TaxedMoney](#taxedmoney)
+    * [TaxedMoneyRange](#taxedmoneyrange)
+    * [Transaction](#transaction)
+    * [TranslatableItemConnection](#translatableitemconnection)
+    * [TranslatableItemEdge](#translatableitemedge)
+    * [User](#user)
+    * [UserAvatarDelete](#useravatardelete)
+    * [UserAvatarUpdate](#useravatarupdate)
+    * [UserBulkSetActive](#userbulksetactive)
+    * [UserClearStoredMeta](#userclearstoredmeta)
+    * [UserClearStoredPrivateMeta](#userclearstoredprivatemeta)
+    * [UserCountableConnection](#usercountableconnection)
+    * [UserCountableEdge](#usercountableedge)
+    * [UserUpdateMeta](#userupdatemeta)
+    * [UserUpdatePrivateMeta](#userupdateprivatemeta)
+    * [VAT](#vat)
+    * [VariantImageAssign](#variantimageassign)
+    * [VariantImageUnassign](#variantimageunassign)
+    * [VariantPricingInfo](#variantpricinginfo)
+    * [VerifyToken](#verifytoken)
+    * [Voucher](#voucher)
+    * [VoucherAddCatalogues](#voucheraddcatalogues)
+    * [VoucherBulkDelete](#voucherbulkdelete)
+    * [VoucherCountableConnection](#vouchercountableconnection)
+    * [VoucherCountableEdge](#vouchercountableedge)
+    * [VoucherCreate](#vouchercreate)
+    * [VoucherDelete](#voucherdelete)
+    * [VoucherRemoveCatalogues](#voucherremovecatalogues)
+    * [VoucherTranslate](#vouchertranslate)
+    * [VoucherTranslation](#vouchertranslation)
+    * [VoucherUpdate](#voucherupdate)
+    * [Weight](#weight)
+  * [Inputs](#inputs)
+    * [AccountInput](#accountinput)
+    * [AccountRegisterInput](#accountregisterinput)
+    * [AddressInput](#addressinput)
+    * [AttributeAssignInput](#attributeassigninput)
+    * [AttributeCreateInput](#attributecreateinput)
+    * [AttributeFilterInput](#attributefilterinput)
+    * [AttributeInput](#attributeinput)
+    * [AttributeSortingInput](#attributesortinginput)
+    * [AttributeUpdateInput](#attributeupdateinput)
+    * [AttributeValueCreateInput](#attributevaluecreateinput)
+    * [AttributeValueInput](#attributevalueinput)
+    * [AuthorizationKeyInput](#authorizationkeyinput)
+    * [CatalogueInput](#catalogueinput)
+    * [CategoryFilterInput](#categoryfilterinput)
+    * [CategoryInput](#categoryinput)
+    * [CheckoutCreateInput](#checkoutcreateinput)
+    * [CheckoutLineInput](#checkoutlineinput)
+    * [CollectionCreateInput](#collectioncreateinput)
+    * [CollectionFilterInput](#collectionfilterinput)
+    * [CollectionInput](#collectioninput)
+    * [ConfigurationItemInput](#configurationiteminput)
+    * [CustomerFilterInput](#customerfilterinput)
+    * [CustomerInput](#customerinput)
+    * [CustomerPasswordResetInput](#customerpasswordresetinput)
+    * [CustomerRegisterInput](#customerregisterinput)
+    * [DateRangeInput](#daterangeinput)
+    * [DateTimeRangeInput](#datetimerangeinput)
+    * [DigitalContentInput](#digitalcontentinput)
+    * [DigitalContentUploadInput](#digitalcontentuploadinput)
+    * [DigitalContentUrlCreateInput](#digitalcontenturlcreateinput)
+    * [DraftOrderCreateInput](#draftordercreateinput)
+    * [DraftOrderInput](#draftorderinput)
+    * [FulfillmentCancelInput](#fulfillmentcancelinput)
+    * [FulfillmentCreateInput](#fulfillmentcreateinput)
+    * [FulfillmentLineInput](#fulfillmentlineinput)
+    * [FulfillmentUpdateTrackingInput](#fulfillmentupdatetrackinginput)
+    * [GiftCardCreateInput](#giftcardcreateinput)
+    * [GiftCardUpdateInput](#giftcardupdateinput)
+    * [IntRangeInput](#intrangeinput)
+    * [MenuCreateInput](#menucreateinput)
+    * [MenuFilterInput](#menufilterinput)
+    * [MenuInput](#menuinput)
+    * [MenuItemCreateInput](#menuitemcreateinput)
+    * [MenuItemFilterInput](#menuitemfilterinput)
+    * [MenuItemInput](#menuiteminput)
+    * [MenuItemMoveInput](#menuitemmoveinput)
+    * [MetaInput](#metainput)
+    * [MetaPath](#metapath)
+    * [MoveProductInput](#moveproductinput)
+    * [NameTranslationInput](#nametranslationinput)
+    * [OrderAddNoteInput](#orderaddnoteinput)
+    * [OrderDraftFilterInput](#orderdraftfilterinput)
+    * [OrderFilterInput](#orderfilterinput)
+    * [OrderLineCreateInput](#orderlinecreateinput)
+    * [OrderLineInput](#orderlineinput)
+    * [OrderUpdateInput](#orderupdateinput)
+    * [OrderUpdateShippingInput](#orderupdateshippinginput)
+    * [PageFilterInput](#pagefilterinput)
+    * [PageInput](#pageinput)
+    * [PageTranslationInput](#pagetranslationinput)
+    * [PaymentInput](#paymentinput)
+    * [PluginFilterInput](#pluginfilterinput)
+    * [PluginUpdateInput](#pluginupdateinput)
+    * [PriceRangeInput](#pricerangeinput)
+    * [ProductCreateInput](#productcreateinput)
+    * [ProductFilterInput](#productfilterinput)
+    * [ProductImageCreateInput](#productimagecreateinput)
+    * [ProductImageUpdateInput](#productimageupdateinput)
+    * [ProductInput](#productinput)
+    * [ProductOrder](#productorder)
+    * [ProductTypeFilterInput](#producttypefilterinput)
+    * [ProductTypeInput](#producttypeinput)
+    * [ProductVariantCreateInput](#productvariantcreateinput)
+    * [ProductVariantInput](#productvariantinput)
+    * [ReorderInput](#reorderinput)
+    * [SaleFilterInput](#salefilterinput)
+    * [SaleInput](#saleinput)
+    * [SeoInput](#seoinput)
+    * [ServiceAccountFilterInput](#serviceaccountfilterinput)
+    * [ServiceAccountInput](#serviceaccountinput)
+    * [ShippingPriceInput](#shippingpriceinput)
+    * [ShippingZoneInput](#shippingzoneinput)
+    * [ShopSettingsInput](#shopsettingsinput)
+    * [ShopSettingsTranslationInput](#shopsettingstranslationinput)
+    * [SiteDomainInput](#sitedomaininput)
+    * [StaffCreateInput](#staffcreateinput)
+    * [StaffInput](#staffinput)
+    * [StaffUserInput](#staffuserinput)
+    * [TranslationInput](#translationinput)
+    * [UserAddressInput](#useraddressinput)
+    * [UserCreateInput](#usercreateinput)
+    * [VoucherFilterInput](#voucherfilterinput)
+    * [VoucherInput](#voucherinput)
+  * [Enums](#enums)
+    * [AccountErrorCode](#accounterrorcode)
+    * [AddressTypeEnum](#addresstypeenum)
+    * [AttributeInputTypeEnum](#attributeinputtypeenum)
+    * [AttributeSortField](#attributesortfield)
+    * [AttributeTypeEnum](#attributetypeenum)
+    * [AttributeValueType](#attributevaluetype)
+    * [AuthorizationKeyType](#authorizationkeytype)
+    * [CheckoutErrorCode](#checkouterrorcode)
+    * [CollectionPublished](#collectionpublished)
+    * [ConfigurationTypeFieldEnum](#configurationtypefieldenum)
+    * [CountryCode](#countrycode)
+    * [CustomerEventsEnum](#customereventsenum)
+    * [DiscountStatusEnum](#discountstatusenum)
+    * [DiscountValueTypeEnum](#discountvaluetypeenum)
+    * [ExtensionsErrorCode](#extensionserrorcode)
+    * [FulfillmentStatus](#fulfillmentstatus)
+    * [GatewaysEnum](#gatewaysenum)
+    * [GiftCardErrorCode](#giftcarderrorcode)
+    * [LanguageCodeEnum](#languagecodeenum)
+    * [MenuErrorCode](#menuerrorcode)
+    * [NavigationType](#navigationtype)
+    * [OrderAction](#orderaction)
+    * [OrderDirection](#orderdirection)
+    * [OrderErrorCode](#ordererrorcode)
+    * [OrderEventsEmailsEnum](#ordereventsemailsenum)
+    * [OrderEventsEnum](#ordereventsenum)
+    * [OrderStatus](#orderstatus)
+    * [OrderStatusFilter](#orderstatusfilter)
+    * [PaymentChargeStatusEnum](#paymentchargestatusenum)
+    * [PaymentErrorCode](#paymenterrorcode)
+    * [PermissionEnum](#permissionenum)
+    * [ProductErrorCode](#producterrorcode)
+    * [ProductOrderField](#productorderfield)
+    * [ProductTypeConfigurable](#producttypeconfigurable)
+    * [ProductTypeEnum](#producttypeenum)
+    * [ReportingPeriod](#reportingperiod)
+    * [SaleType](#saletype)
+    * [ShippingErrorCode](#shippingerrorcode)
+    * [ShippingMethodTypeEnum](#shippingmethodtypeenum)
+    * [ShopErrorCode](#shoperrorcode)
+    * [StaffMemberStatus](#staffmemberstatus)
+    * [StockAvailability](#stockavailability)
+    * [TaxRateType](#taxratetype)
+    * [TransactionError](#transactionerror)
+    * [TransactionKind](#transactionkind)
+    * [TranslatableKinds](#translatablekinds)
+    * [VoucherDiscountType](#voucherdiscounttype)
+    * [VoucherTypeEnum](#vouchertypeenum)
+    * [WeightUnitsEnum](#weightunitsenum)
+  * [Scalars](#scalars)
+    * [AttributeScalar](#attributescalar)
+    * [Boolean](#boolean)
+    * [Date](#date)
+    * [DateTime](#datetime)
+    * [Decimal](#decimal)
+    * [Float](#float)
+    * [GenericScalar](#genericscalar)
+    * [ID](#id)
+    * [Int](#int)
+    * [JSONString](#jsonstring)
+    * [String](#string)
+    * [UUID](#uuid)
+    * [Upload](#upload)
+    * [WeightScalar](#weightscalar)
+  * [Interfaces](#interfaces)
+    * [Node](#node)
+
+</details>
+
+## Query
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>translations</strong></td>
+<td valign="top"><a href="#translatableitemconnection">TranslatableItemConnection</a></td>
+<td>
+
+Returns list of all translatable items of a given kind.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">kind</td>
+<td valign="top"><a href="#translatablekinds">TranslatableKinds</a>!</td>
+<td>
+
+Kind of objects to retrieve.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Return information about the shop.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td>
+
+Lookup a shipping zone by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZones</strong></td>
+<td valign="top"><a href="#shippingzonecountableconnection">ShippingZoneCountableConnection</a></td>
+<td>
+
+List of the shop's shipping zones.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContent</strong></td>
+<td valign="top"><a href="#digitalcontent">DigitalContent</a></td>
+<td>
+
+Lookup a digital content by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the digital content.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContents</strong></td>
+<td valign="top"><a href="#digitalcontentcountableconnection">DigitalContentCountableConnection</a></td>
+<td>
+
+List of the digital contents.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top"><a href="#attributecountableconnection">AttributeCountableConnection</a></td>
+<td>
+
+List of the shop's attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`, `slug`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">inCategory</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Return attributes for products
+            belonging to the given category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">inCollection</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Return attributes for products
+            belonging to the given collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#attributefilterinput">AttributeFilterInput</a></td>
+<td>
+
+Filtering options for attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sortBy</td>
+<td valign="top"><a href="#attributesortinginput">AttributeSortingInput</a></td>
+<td>
+
+Sorting options for attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td>
+
+Lookup an attribute by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top"><a href="#categorycountableconnection">CategoryCountableConnection</a></td>
+<td>
+
+List of the shop's categories.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`, `slug`, `description`, `parent__name`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#categoryfilterinput">CategoryFilterInput</a></td>
+<td>
+
+Filtering options for categories.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">level</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Filter categories by the nesting level in the category tree.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td>
+
+Lookup a category by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td>
+
+Lookup a collection by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top"><a href="#collectioncountableconnection">CollectionCountableConnection</a></td>
+<td>
+
+List of the shop's collections.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#collectionfilterinput">CollectionFilterInput</a></td>
+<td>
+
+Filtering options for collections.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`, `slug`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td>
+
+Lookup a product by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top"><a href="#productcountableconnection">ProductCountableConnection</a></td>
+<td>
+
+List of the shop's products.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#productfilterinput">ProductFilterInput</a></td>
+<td>
+
+Filtering options for products.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">attributes</td>
+<td valign="top">[<a href="#attributescalar">AttributeScalar</a>]</td>
+<td>
+
+Filter products by attributes. DEPRECATED: Will be removed in Saleor 2.10, use the `filter` field instead.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">categories</td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Filter products by category. DEPRECATED: Will be removed in Saleor 2.10, use the `filter` field instead.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">collections</td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Filter products by collections. DEPRECATED: Will be removed in Saleor 2.10, use the `filter` field instead.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sortBy</td>
+<td valign="top"><a href="#productorder">ProductOrder</a></td>
+<td>
+
+Sort products.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">stockAvailability</td>
+<td valign="top"><a href="#stockavailability">StockAvailability</a></td>
+<td>
+
+Filter products by the stock availability
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`, `description`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td>
+
+Lookup a product type by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypes</strong></td>
+<td valign="top"><a href="#producttypecountableconnection">ProductTypeCountableConnection</a></td>
+<td>
+
+List of the shop's product types.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#producttypefilterinput">ProductTypeFilterInput</a></td>
+<td>
+
+Filtering options for product types.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td>
+
+Lookup a product variant by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the product variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariants</strong></td>
+<td valign="top"><a href="#productvariantcountableconnection">ProductVariantCountableConnection</a></td>
+<td>
+
+List of product variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Filter product variants by given IDs.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>reportProductSales</strong></td>
+<td valign="top"><a href="#productvariantcountableconnection">ProductVariantCountableConnection</a></td>
+<td>
+
+List of top selling products.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">period</td>
+<td valign="top"><a href="#reportingperiod">ReportingPeriod</a>!</td>
+<td>
+
+Span of time.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a></td>
+<td>
+
+Lookup a payment by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payments</strong></td>
+<td valign="top"><a href="#paymentcountableconnection">PaymentCountableConnection</a></td>
+<td>
+
+List of payments
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentClientToken</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Return a new token for the payment gateway.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">gateway</td>
+<td valign="top"><a href="#gatewaysenum">GatewaysEnum</a></td>
+<td>
+
+A payment gateway.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#page">Page</a></td>
+<td>
+
+Lookup a page by ID or slug.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">slug</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The slug of the page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pages</strong></td>
+<td valign="top"><a href="#pagecountableconnection">PageCountableConnection</a></td>
+<td>
+
+List of the shop's pages.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`content`, `slug`, `title`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#pagefilterinput">PageFilterInput</a></td>
+<td>
+
+Filtering options for pages.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>homepageEvents</strong></td>
+<td valign="top"><a href="#ordereventcountableconnection">OrderEventCountableConnection</a></td>
+<td>
+
+List of activity events to display on
+        homepage (at the moment it only contains order-events).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Lookup an order by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orders</strong></td>
+<td valign="top"><a href="#ordercountableconnection">OrderCountableConnection</a></td>
+<td>
+
+List of orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#orderfilterinput">OrderFilterInput</a></td>
+<td>
+
+Filtering options for orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`id`, `discount_name`, `token`, `user_email`, `user__email`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">created</td>
+<td valign="top"><a href="#reportingperiod">ReportingPeriod</a></td>
+<td>
+
+Filter orders from a selected timespan.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">status</td>
+<td valign="top"><a href="#orderstatusfilter">OrderStatusFilter</a></td>
+<td>
+
+Filter order by status
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrders</strong></td>
+<td valign="top"><a href="#ordercountableconnection">OrderCountableConnection</a></td>
+<td>
+
+List of draft orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#orderdraftfilterinput">OrderDraftFilterInput</a></td>
+<td>
+
+Filtering options for draft orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`id`, `discount_name`, `token`, `user_email`, `user__email`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">created</td>
+<td valign="top"><a href="#reportingperiod">ReportingPeriod</a></td>
+<td>
+
+Filter draft orders from a selected timespan.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>ordersTotal</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Return the total sales amount from a specific period.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">period</td>
+<td valign="top"><a href="#reportingperiod">ReportingPeriod</a></td>
+<td>
+
+A period of time.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderByToken</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Lookup an order by token.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#uuid">UUID</a>!</td>
+<td>
+
+The order's token.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td>
+
+Lookup a navigation menu by ID or name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">name</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The menu's name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menus</strong></td>
+<td valign="top"><a href="#menucountableconnection">MenuCountableConnection</a></td>
+<td>
+
+List of the storefront's menus.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#menufilterinput">MenuFilterInput</a></td>
+<td>
+
+Filtering options for menus.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItem</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a></td>
+<td>
+
+Lookup a menu item by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItems</strong></td>
+<td valign="top"><a href="#menuitemcountableconnection">MenuItemCountableConnection</a></td>
+<td>
+
+List of the storefronts's menu items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`name`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#menuitemfilterinput">MenuItemFilterInput</a></td>
+<td>
+
+Filtering options for menu items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCard</strong></td>
+<td valign="top"><a href="#giftcard">GiftCard</a></td>
+<td>
+
+Lookup a gift card by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCards</strong></td>
+<td valign="top"><a href="#giftcardcountableconnection">GiftCardCountableConnection</a></td>
+<td>
+
+List of gift cards
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>plugin</strong></td>
+<td valign="top"><a href="#plugin">Plugin</a></td>
+<td>
+
+Lookup a plugin by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the plugin.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>plugins</strong></td>
+<td valign="top"><a href="#plugincountableconnection">PluginCountableConnection</a></td>
+<td>
+
+List of plugins
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#pluginfilterinput">PluginFilterInput</a></td>
+<td>
+
+Filtering options for plugins
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td>
+
+Lookup a sale by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sales</strong></td>
+<td valign="top"><a href="#salecountableconnection">SaleCountableConnection</a></td>
+<td>
+
+List of the shop's sales.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#salefilterinput">SaleFilterInput</a></td>
+<td>
+
+Filtering options for sales.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Search sales by name, value or type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td>
+
+Lookup a voucher by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>vouchers</strong></td>
+<td valign="top"><a href="#vouchercountableconnection">VoucherCountableConnection</a></td>
+<td>
+
+List of the shop's vouchers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#voucherfilterinput">VoucherFilterInput</a></td>
+<td>
+
+Filtering options for vouchers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Search vouchers by name or code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxTypes</strong></td>
+<td valign="top">[<a href="#taxtype">TaxType</a>]</td>
+<td>
+
+List of all tax rates available from tax gateway
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+Lookup a checkout by token.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#uuid">UUID</a></td>
+<td>
+
+The checkout's token
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkouts</strong></td>
+<td valign="top"><a href="#checkoutcountableconnection">CheckoutCountableConnection</a></td>
+<td>
+
+List of checkouts.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutLine</strong></td>
+<td valign="top"><a href="#checkoutline">CheckoutLine</a></td>
+<td>
+
+Lookup a checkout line by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the checkout line.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutLines</strong></td>
+<td valign="top"><a href="#checkoutlinecountableconnection">CheckoutLineCountableConnection</a></td>
+<td>
+
+List of checkout lines
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressValidationRules</strong></td>
+<td valign="top"><a href="#addressvalidationdata">AddressValidationData</a></td>
+<td>
+
+Returns address validation rules.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">countryCode</td>
+<td valign="top"><a href="#countrycode">CountryCode</a>!</td>
+<td>
+
+Two-letter ISO 3166-1 country code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">countryArea</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Designation of a region, province or state.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">city</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+City or a town name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">cityArea</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Sublocality like a district.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customers</strong></td>
+<td valign="top"><a href="#usercountableconnection">UserCountableConnection</a></td>
+<td>
+
+List of the shop's customers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#customerfilterinput">CustomerFilterInput</a></td>
+<td>
+
+Filtering options for customers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`email`, `first_name`, `last_name`, `default_shipping_address__first_name`, `default_shipping_address__last_name`, `default_shipping_address__city`, `default_shipping_address__country`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>me</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+Return the currently authenticated user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>staffUsers</strong></td>
+<td valign="top"><a href="#usercountableconnection">UserCountableConnection</a></td>
+<td>
+
+List of the shop's staff users.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#staffuserinput">StaffUserInput</a></td>
+<td>
+
+Filtering options for staff users.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">query</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use `filter: {search: {}}` instead.
+Supported filter parameters:
+`email`, `first_name`, `last_name`, `default_shipping_address__first_name`, `default_shipping_address__last_name`, `default_shipping_address__city`, `default_shipping_address__country`
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccounts</strong></td>
+<td valign="top"><a href="#serviceaccountcountableconnection">ServiceAccountCountableConnection</a></td>
+<td>
+
+List of the service accounts
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#serviceaccountfilterinput">ServiceAccountFilterInput</a></td>
+<td>
+
+Filtering options for service accounts.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccount</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a></td>
+<td>
+
+Lookup a service account by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the service account.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+Lookup an user by ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#node">Node</a></td>
+<td>
+
+The ID of the object
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Mutation (Mutations)
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>authorizationKeyAdd</strong></td>
+<td valign="top"><a href="#authorizationkeyadd">AuthorizationKeyAdd</a></td>
+<td>
+
+Adds an authorization key.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#authorizationkeyinput">AuthorizationKeyInput</a>!</td>
+<td>
+
+Fields required to create an authorization key.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">keyType</td>
+<td valign="top"><a href="#authorizationkeytype">AuthorizationKeyType</a>!</td>
+<td>
+
+Type of an authorization key to add.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>authorizationKeyDelete</strong></td>
+<td valign="top"><a href="#authorizationkeydelete">AuthorizationKeyDelete</a></td>
+<td>
+
+Deletes an authorization key.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">keyType</td>
+<td valign="top"><a href="#authorizationkeytype">AuthorizationKeyType</a>!</td>
+<td>
+
+Type of a key to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>homepageCollectionUpdate</strong></td>
+<td valign="top"><a href="#homepagecollectionupdate">HomepageCollectionUpdate</a></td>
+<td>
+
+Updates homepage collection of the shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">collection</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Collection displayed on homepage
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopDomainUpdate</strong></td>
+<td valign="top"><a href="#shopdomainupdate">ShopDomainUpdate</a></td>
+<td>
+
+Updates site domain of the shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#sitedomaininput">SiteDomainInput</a></td>
+<td>
+
+Fields required to update site
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopSettingsUpdate</strong></td>
+<td valign="top"><a href="#shopsettingsupdate">ShopSettingsUpdate</a></td>
+<td>
+
+Updates shop settings
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#shopsettingsinput">ShopSettingsInput</a>!</td>
+<td>
+
+Fields required to update shop settings.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopFetchTaxRates</strong></td>
+<td valign="top"><a href="#shopfetchtaxrates">ShopFetchTaxRates</a></td>
+<td>
+
+Fetch tax rates
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopSettingsTranslate</strong></td>
+<td valign="top"><a href="#shopsettingstranslate">ShopSettingsTranslate</a></td>
+<td>
+
+Creates/Updates translations for Shop Settings.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#shopsettingstranslationinput">ShopSettingsTranslationInput</a>!</td>
+<td>
+
+Fields required to update shop settings translations.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopAddressUpdate</strong></td>
+<td valign="top"><a href="#shopaddressupdate">ShopAddressUpdate</a></td>
+<td>
+
+Update shop address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Fields required to update shop address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPriceCreate</strong></td>
+<td valign="top"><a href="#shippingpricecreate">ShippingPriceCreate</a></td>
+<td>
+
+Creates a new shipping price.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#shippingpriceinput">ShippingPriceInput</a>!</td>
+<td>
+
+Fields required to create a shipping price
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPriceDelete</strong></td>
+<td valign="top"><a href="#shippingpricedelete">ShippingPriceDelete</a></td>
+<td>
+
+Deletes a shipping price.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a shipping price to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPriceBulkDelete</strong></td>
+<td valign="top"><a href="#shippingpricebulkdelete">ShippingPriceBulkDelete</a></td>
+<td>
+
+Deletes shipping prices.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of shipping price IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPriceUpdate</strong></td>
+<td valign="top"><a href="#shippingpriceupdate">ShippingPriceUpdate</a></td>
+<td>
+
+Updates a new shipping price.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a shipping price to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#shippingpriceinput">ShippingPriceInput</a>!</td>
+<td>
+
+Fields required to update a shipping price
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPriceTranslate</strong></td>
+<td valign="top"><a href="#shippingpricetranslate">ShippingPriceTranslate</a></td>
+<td>
+
+Creates/Updates translations for Shipping Method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Shipping Method ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZoneCreate</strong></td>
+<td valign="top"><a href="#shippingzonecreate">ShippingZoneCreate</a></td>
+<td>
+
+Creates a new shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#shippingzoneinput">ShippingZoneInput</a>!</td>
+<td>
+
+Fields required to create a shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZoneDelete</strong></td>
+<td valign="top"><a href="#shippingzonedelete">ShippingZoneDelete</a></td>
+<td>
+
+Deletes a shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a shipping zone to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZoneBulkDelete</strong></td>
+<td valign="top"><a href="#shippingzonebulkdelete">ShippingZoneBulkDelete</a></td>
+<td>
+
+Deletes shipping zones.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of shipping zone IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZoneUpdate</strong></td>
+<td valign="top"><a href="#shippingzoneupdate">ShippingZoneUpdate</a></td>
+<td>
+
+Updates a new shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a shipping zone to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#shippingzoneinput">ShippingZoneInput</a>!</td>
+<td>
+
+Fields required to update a shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeCreate</strong></td>
+<td valign="top"><a href="#attributecreate">AttributeCreate</a></td>
+<td>
+
+Creates an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#attributecreateinput">AttributeCreateInput</a>!</td>
+<td>
+
+Fields required to create an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeDelete</strong></td>
+<td valign="top"><a href="#attributedelete">AttributeDelete</a></td>
+<td>
+
+Deletes an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an attribute to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeBulkDelete</strong></td>
+<td valign="top"><a href="#attributebulkdelete">AttributeBulkDelete</a></td>
+<td>
+
+Deletes attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of attribute IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeAssign</strong></td>
+<td valign="top"><a href="#attributeassign">AttributeAssign</a></td>
+<td>
+
+Assign attributes to a given product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">operations</td>
+<td valign="top">[<a href="#attributeassigninput">AttributeAssignInput</a>]!</td>
+<td>
+
+The operations to perform.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">productTypeId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the product type to assign the attributes into.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeUnassign</strong></td>
+<td valign="top"><a href="#attributeunassign">AttributeUnassign</a></td>
+<td>
+
+Un-assign attributes from a given product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">attributeIds</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+The IDs of the attributes to assign
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">productTypeId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the product type to assign the attributes into.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeUpdate</strong></td>
+<td valign="top"><a href="#attributeupdate">AttributeUpdate</a></td>
+<td>
+
+Updates attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an attribute to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#attributeupdateinput">AttributeUpdateInput</a>!</td>
+<td>
+
+Fields required to update an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeTranslate</strong></td>
+<td valign="top"><a href="#attributetranslate">AttributeTranslate</a></td>
+<td>
+
+Creates/Updates translations for Attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Attribute ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeUpdateMetadata</strong></td>
+<td valign="top"><a href="#attributeupdatemeta">AttributeUpdateMeta</a></td>
+<td>
+
+Update public metadata for Attribute 
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeClearMetadata</strong></td>
+<td valign="top"><a href="#attributeclearmeta">AttributeClearMeta</a></td>
+<td>
+
+Clears public metadata item for Attribute
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#attributeupdateprivatemeta">AttributeUpdatePrivateMeta</a></td>
+<td>
+
+Update public metadata for Attribute
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#attributeclearprivatemeta">AttributeClearPrivateMeta</a></td>
+<td>
+
+Clears public metadata item for Attribute
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValueCreate</strong></td>
+<td valign="top"><a href="#attributevaluecreate">AttributeValueCreate</a></td>
+<td>
+
+Creates a value for an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">attribute</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Attribute to which value will be assigned.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#attributevaluecreateinput">AttributeValueCreateInput</a>!</td>
+<td>
+
+Fields required to create an AttributeValue.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValueDelete</strong></td>
+<td valign="top"><a href="#attributevaluedelete">AttributeValueDelete</a></td>
+<td>
+
+Deletes a value of an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a value to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValueBulkDelete</strong></td>
+<td valign="top"><a href="#attributevaluebulkdelete">AttributeValueBulkDelete</a></td>
+<td>
+
+Deletes values of attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of attribute value IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValueUpdate</strong></td>
+<td valign="top"><a href="#attributevalueupdate">AttributeValueUpdate</a></td>
+<td>
+
+Updates value of an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an AttributeValue to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#attributevaluecreateinput">AttributeValueCreateInput</a>!</td>
+<td>
+
+Fields required to update an AttributeValue.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValueTranslate</strong></td>
+<td valign="top"><a href="#attributevaluetranslate">AttributeValueTranslate</a></td>
+<td>
+
+Creates/Updates translations for Attribute Value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Attribute Value ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeReorderValues</strong></td>
+<td valign="top"><a href="#attributereordervalues">AttributeReorderValues</a></td>
+<td>
+
+Reorder the values of an attribute
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">attributeId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">moves</td>
+<td valign="top">[<a href="#reorderinput">ReorderInput</a>]!</td>
+<td>
+
+The list of reordering operations for given attribute values.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryCreate</strong></td>
+<td valign="top"><a href="#categorycreate">CategoryCreate</a></td>
+<td>
+
+Creates a new category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#categoryinput">CategoryInput</a>!</td>
+<td>
+
+Fields required to create a category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">parent</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+
+                ID of the parent category. If empty, category will be top level
+                category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryDelete</strong></td>
+<td valign="top"><a href="#categorydelete">CategoryDelete</a></td>
+<td>
+
+Deletes a category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a category to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryBulkDelete</strong></td>
+<td valign="top"><a href="#categorybulkdelete">CategoryBulkDelete</a></td>
+<td>
+
+Deletes categories.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of category IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryUpdate</strong></td>
+<td valign="top"><a href="#categoryupdate">CategoryUpdate</a></td>
+<td>
+
+Updates a category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a category to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#categoryinput">CategoryInput</a>!</td>
+<td>
+
+Fields required to update a category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryTranslate</strong></td>
+<td valign="top"><a href="#categorytranslate">CategoryTranslate</a></td>
+<td>
+
+Creates/Updates translations for Category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Category ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#translationinput">TranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryUpdateMetadata</strong></td>
+<td valign="top"><a href="#categoryupdatemeta">CategoryUpdateMeta</a></td>
+<td>
+
+Update public metadata for category
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryClearMetadata</strong></td>
+<td valign="top"><a href="#categoryclearmeta">CategoryClearMeta</a></td>
+<td>
+
+Clears public metadata item for category
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#categoryupdateprivatemeta">CategoryUpdatePrivateMeta</a></td>
+<td>
+
+Update public metadata for category
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#categoryclearprivatemeta">CategoryClearPrivateMeta</a></td>
+<td>
+
+Clears public metadata item for category
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionAddProducts</strong></td>
+<td valign="top"><a href="#collectionaddproducts">CollectionAddProducts</a></td>
+<td>
+
+Adds products to a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">collectionId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">products</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of product IDs.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionCreate</strong></td>
+<td valign="top"><a href="#collectioncreate">CollectionCreate</a></td>
+<td>
+
+Creates a new collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#collectioncreateinput">CollectionCreateInput</a>!</td>
+<td>
+
+Fields required to create a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionDelete</strong></td>
+<td valign="top"><a href="#collectiondelete">CollectionDelete</a></td>
+<td>
+
+Deletes a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a collection to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionReorderProducts</strong></td>
+<td valign="top"><a href="#collectionreorderproducts">CollectionReorderProducts</a></td>
+<td>
+
+Reorder the products of a collection
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">collectionId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">moves</td>
+<td valign="top">[<a href="#moveproductinput">MoveProductInput</a>]!</td>
+<td>
+
+The collection products position operations.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionBulkDelete</strong></td>
+<td valign="top"><a href="#collectionbulkdelete">CollectionBulkDelete</a></td>
+<td>
+
+Deletes collections.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of collection IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionBulkPublish</strong></td>
+<td valign="top"><a href="#collectionbulkpublish">CollectionBulkPublish</a></td>
+<td>
+
+Publish collections.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of collections IDs to (un)publish.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">isPublished</td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Determine if collections will be published or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionRemoveProducts</strong></td>
+<td valign="top"><a href="#collectionremoveproducts">CollectionRemoveProducts</a></td>
+<td>
+
+Remove products from a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">collectionId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">products</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of product IDs.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionUpdate</strong></td>
+<td valign="top"><a href="#collectionupdate">CollectionUpdate</a></td>
+<td>
+
+Updates a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a collection to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#collectioninput">CollectionInput</a>!</td>
+<td>
+
+Fields required to update a collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionTranslate</strong></td>
+<td valign="top"><a href="#collectiontranslate">CollectionTranslate</a></td>
+<td>
+
+Creates/Updates translations for Collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Collection ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#translationinput">TranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionUpdateMetadata</strong></td>
+<td valign="top"><a href="#collectionupdatemeta">CollectionUpdateMeta</a></td>
+<td>
+
+Update public metadata for Collection
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionClearMetadata</strong></td>
+<td valign="top"><a href="#collectionclearmeta">CollectionClearMeta</a></td>
+<td>
+
+Clears public metadata item for Collection
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#collectionupdateprivatemeta">CollectionUpdatePrivateMeta</a></td>
+<td>
+
+Update public metadata for Collection
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collectionClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#collectionclearprivatemeta">CollectionClearPrivateMeta</a></td>
+<td>
+
+Clears public metadata item for Collection
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productCreate</strong></td>
+<td valign="top"><a href="#productcreate">ProductCreate</a></td>
+<td>
+
+Creates a new product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#productcreateinput">ProductCreateInput</a>!</td>
+<td>
+
+Fields required to create a product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productDelete</strong></td>
+<td valign="top"><a href="#productdelete">ProductDelete</a></td>
+<td>
+
+Deletes a product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productBulkDelete</strong></td>
+<td valign="top"><a href="#productbulkdelete">ProductBulkDelete</a></td>
+<td>
+
+Deletes products.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of product IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productBulkPublish</strong></td>
+<td valign="top"><a href="#productbulkpublish">ProductBulkPublish</a></td>
+<td>
+
+Publish products.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of products IDs to publish.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">isPublished</td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Determine if products will be published or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productUpdate</strong></td>
+<td valign="top"><a href="#productupdate">ProductUpdate</a></td>
+<td>
+
+Updates an existing product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#productinput">ProductInput</a>!</td>
+<td>
+
+Fields required to update a product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTranslate</strong></td>
+<td valign="top"><a href="#producttranslate">ProductTranslate</a></td>
+<td>
+
+Creates/Updates translations for Product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Product ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#translationinput">TranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productUpdateMetadata</strong></td>
+<td valign="top"><a href="#productupdatemeta">ProductUpdateMeta</a></td>
+<td>
+
+Update public metadata for product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productClearMetadata</strong></td>
+<td valign="top"><a href="#productclearmeta">ProductClearMeta</a></td>
+<td>
+
+Clears public metadata item for product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#productupdateprivatemeta">ProductUpdatePrivateMeta</a></td>
+<td>
+
+Update public metadata for product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#productclearprivatemeta">ProductClearPrivateMeta</a></td>
+<td>
+
+Clears public metadata item for product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productImageCreate</strong></td>
+<td valign="top"><a href="#productimagecreate">ProductImageCreate</a></td>
+<td>
+
+Create a product image. This mutation must be
+        sent as a `multipart` request. More detailed specs of the upload format
+        can be found here:
+        https://github.com/jaydenseric/graphql-multipart-request-spec
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#productimagecreateinput">ProductImageCreateInput</a>!</td>
+<td>
+
+Fields required to create a product image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productImageDelete</strong></td>
+<td valign="top"><a href="#productimagedelete">ProductImageDelete</a></td>
+<td>
+
+Deletes a product image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product image to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productImageBulkDelete</strong></td>
+<td valign="top"><a href="#productimagebulkdelete">ProductImageBulkDelete</a></td>
+<td>
+
+Deletes product images.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of product image IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productImageReorder</strong></td>
+<td valign="top"><a href="#productimagereorder">ProductImageReorder</a></td>
+<td>
+
+Changes ordering of the product image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">imagesIds</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+IDs of a product images in the desired order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">productId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Id of product that images order will be altered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productImageUpdate</strong></td>
+<td valign="top"><a href="#productimageupdate">ProductImageUpdate</a></td>
+<td>
+
+Updates a product image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product image to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#productimageupdateinput">ProductImageUpdateInput</a>!</td>
+<td>
+
+Fields required to update a product image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeCreate</strong></td>
+<td valign="top"><a href="#producttypecreate">ProductTypeCreate</a></td>
+<td>
+
+Creates a new product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#producttypeinput">ProductTypeInput</a>!</td>
+<td>
+
+Fields required to create a product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeDelete</strong></td>
+<td valign="top"><a href="#producttypedelete">ProductTypeDelete</a></td>
+<td>
+
+Deletes a product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product type to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeBulkDelete</strong></td>
+<td valign="top"><a href="#producttypebulkdelete">ProductTypeBulkDelete</a></td>
+<td>
+
+Deletes product types.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of product type IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeUpdate</strong></td>
+<td valign="top"><a href="#producttypeupdate">ProductTypeUpdate</a></td>
+<td>
+
+Updates an existing product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product type to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#producttypeinput">ProductTypeInput</a>!</td>
+<td>
+
+Fields required to update a product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeReorderAttributes</strong></td>
+<td valign="top"><a href="#producttypereorderattributes">ProductTypeReorderAttributes</a></td>
+<td>
+
+Reorder the attributes of a product type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">moves</td>
+<td valign="top">[<a href="#reorderinput">ReorderInput</a>]!</td>
+<td>
+
+The list of attribute reordering operations.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">productTypeId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#attributetypeenum">AttributeTypeEnum</a>!</td>
+<td>
+
+The attribute type to reorder.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeUpdateMetadata</strong></td>
+<td valign="top"><a href="#producttypeupdatemeta">ProductTypeUpdateMeta</a></td>
+<td>
+
+Update public metadata for product type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeClearMetadata</strong></td>
+<td valign="top"><a href="#producttypeclearmeta">ProductTypeClearMeta</a></td>
+<td>
+
+Clears public metadata item for product type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#producttypeupdateprivatemeta">ProductTypeUpdatePrivateMeta</a></td>
+<td>
+
+Update public metadata for product type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypeClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#producttypeclearprivatemeta">ProductTypeClearPrivateMeta</a></td>
+<td>
+
+Clears public metadata item for product type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContentCreate</strong></td>
+<td valign="top"><a href="#digitalcontentcreate">DigitalContentCreate</a></td>
+<td>
+
+Create new digital content. This mutation must
+        be sent as a `multipart` request. More detailed specs of the upload
+        format can be found here:
+        https://github.com/jaydenseric/graphql-multipart-request-spec
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#digitalcontentuploadinput">DigitalContentUploadInput</a>!</td>
+<td>
+
+Fields required to create a digital content.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">variantId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant to upload digital content.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContentDelete</strong></td>
+<td valign="top"><a href="#digitalcontentdelete">DigitalContentDelete</a></td>
+<td>
+
+Remove digital content assigned to given variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">variantId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant with digital content to remove.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContentUpdate</strong></td>
+<td valign="top"><a href="#digitalcontentupdate">DigitalContentUpdate</a></td>
+<td>
+
+Update digital content
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#digitalcontentinput">DigitalContentInput</a>!</td>
+<td>
+
+Fields required to update a digital content.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">variantId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant with digital content to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContentUrlCreate</strong></td>
+<td valign="top"><a href="#digitalcontenturlcreate">DigitalContentUrlCreate</a></td>
+<td>
+
+Generate new url to digital content
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#digitalcontenturlcreateinput">DigitalContentUrlCreateInput</a>!</td>
+<td>
+
+Fields required to create a new url.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantCreate</strong></td>
+<td valign="top"><a href="#productvariantcreate">ProductVariantCreate</a></td>
+<td>
+
+Creates a new variant for a product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#productvariantcreateinput">ProductVariantCreateInput</a>!</td>
+<td>
+
+Fields required to create a product variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantDelete</strong></td>
+<td valign="top"><a href="#productvariantdelete">ProductVariantDelete</a></td>
+<td>
+
+Deletes a product variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantBulkDelete</strong></td>
+<td valign="top"><a href="#productvariantbulkdelete">ProductVariantBulkDelete</a></td>
+<td>
+
+Deletes product variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of product variant IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantUpdate</strong></td>
+<td valign="top"><a href="#productvariantupdate">ProductVariantUpdate</a></td>
+<td>
+
+Updates an existing variant for product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#productvariantinput">ProductVariantInput</a>!</td>
+<td>
+
+Fields required to update a product variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantTranslate</strong></td>
+<td valign="top"><a href="#productvarianttranslate">ProductVariantTranslate</a></td>
+<td>
+
+Creates/Updates translations for Product Variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Product Variant ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantUpdateMetadata</strong></td>
+<td valign="top"><a href="#productvariantupdatemeta">ProductVariantUpdateMeta</a></td>
+<td>
+
+Update public metadata for product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantClearMetadata</strong></td>
+<td valign="top"><a href="#productvariantclearmeta">ProductVariantClearMeta</a></td>
+<td>
+
+Clears public metadata item for product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#productvariantupdateprivatemeta">ProductVariantUpdatePrivateMeta</a></td>
+<td>
+
+Update public metadata for product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#productvariantclearprivatemeta">ProductVariantClearPrivateMeta</a></td>
+<td>
+
+Clears public metadata item for product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantImageAssign</strong></td>
+<td valign="top"><a href="#variantimageassign">VariantImageAssign</a></td>
+<td>
+
+Assign an image to a product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">imageId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product image to assign to a variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">variantId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantImageUnassign</strong></td>
+<td valign="top"><a href="#variantimageunassign">VariantImageUnassign</a></td>
+<td>
+
+Unassign an image from a product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">imageId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product image to unassign from a variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">variantId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a product variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentCapture</strong></td>
+<td valign="top"><a href="#paymentcapture">PaymentCapture</a></td>
+<td>
+
+Captures the authorized payment amount
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">amount</td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Transaction amount
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">paymentId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Payment ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentRefund</strong></td>
+<td valign="top"><a href="#paymentrefund">PaymentRefund</a></td>
+<td>
+
+Refunds the captured payment amount
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">amount</td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Transaction amount
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">paymentId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Payment ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentVoid</strong></td>
+<td valign="top"><a href="#paymentvoid">PaymentVoid</a></td>
+<td>
+
+Voids the authorized payment
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">paymentId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Payment ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentSecureConfirm</strong></td>
+<td valign="top"><a href="#paymentsecureconfirm">PaymentSecureConfirm</a></td>
+<td>
+
+Confirms payment in two step process like 3D secure
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">paymentId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Payment ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pageCreate</strong></td>
+<td valign="top"><a href="#pagecreate">PageCreate</a></td>
+<td>
+
+Creates a new page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#pageinput">PageInput</a>!</td>
+<td>
+
+Fields required to create a page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pageDelete</strong></td>
+<td valign="top"><a href="#pagedelete">PageDelete</a></td>
+<td>
+
+Deletes a page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a page to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pageBulkDelete</strong></td>
+<td valign="top"><a href="#pagebulkdelete">PageBulkDelete</a></td>
+<td>
+
+Deletes pages.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of page IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pageBulkPublish</strong></td>
+<td valign="top"><a href="#pagebulkpublish">PageBulkPublish</a></td>
+<td>
+
+Publish pages.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of page IDs to (un)publish.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">isPublished</td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Determine if pages will be published or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pageUpdate</strong></td>
+<td valign="top"><a href="#pageupdate">PageUpdate</a></td>
+<td>
+
+Updates an existing page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a page to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#pageinput">PageInput</a>!</td>
+<td>
+
+Fields required to update a page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pageTranslate</strong></td>
+<td valign="top"><a href="#pagetranslate">PageTranslate</a></td>
+<td>
+
+Creates/Updates translations for Page.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Page ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#pagetranslationinput">PageTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderComplete</strong></td>
+<td valign="top"><a href="#draftordercomplete">DraftOrderComplete</a></td>
+<td>
+
+Completes creating an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order that will be completed.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderCreate</strong></td>
+<td valign="top"><a href="#draftordercreate">DraftOrderCreate</a></td>
+<td>
+
+Creates a new draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#draftordercreateinput">DraftOrderCreateInput</a>!</td>
+<td>
+
+Fields required to create an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderDelete</strong></td>
+<td valign="top"><a href="#draftorderdelete">DraftOrderDelete</a></td>
+<td>
+
+Deletes a draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a draft order to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderBulkDelete</strong></td>
+<td valign="top"><a href="#draftorderbulkdelete">DraftOrderBulkDelete</a></td>
+<td>
+
+Deletes draft orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of draft order IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderLinesBulkDelete</strong></td>
+<td valign="top"><a href="#draftorderlinesbulkdelete">DraftOrderLinesBulkDelete</a></td>
+<td>
+
+Deletes order lines.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of order lines IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderLinesCreate</strong></td>
+<td valign="top"><a href="#draftorderlinescreate">DraftOrderLinesCreate</a></td>
+<td>
+
+Create order lines for a draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the draft order to add the lines to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top">[<a href="#orderlinecreateinput">OrderLineCreateInput</a>]!</td>
+<td>
+
+Fields required to add order lines.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderLineDelete</strong></td>
+<td valign="top"><a href="#draftorderlinedelete">DraftOrderLineDelete</a></td>
+<td>
+
+Deletes an order line from a draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order line to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderLineUpdate</strong></td>
+<td valign="top"><a href="#draftorderlineupdate">DraftOrderLineUpdate</a></td>
+<td>
+
+Updates an order line of a draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order line to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#orderlineinput">OrderLineInput</a>!</td>
+<td>
+
+Fields required to update an order line
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>draftOrderUpdate</strong></td>
+<td valign="top"><a href="#draftorderupdate">DraftOrderUpdate</a></td>
+<td>
+
+Updates a draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an order to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#draftorderinput">DraftOrderInput</a>!</td>
+<td>
+
+Fields required to update an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderAddNote</strong></td>
+<td valign="top"><a href="#orderaddnote">OrderAddNote</a></td>
+<td>
+
+Adds note to the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">order</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to add a note for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#orderaddnoteinput">OrderAddNoteInput</a>!</td>
+<td>
+
+Fields required to create a note for the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderCancel</strong></td>
+<td valign="top"><a href="#ordercancel">OrderCancel</a></td>
+<td>
+
+Cancel an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to cancel.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">restock</td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Determine if lines will be restocked or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderCapture</strong></td>
+<td valign="top"><a href="#ordercapture">OrderCapture</a></td>
+<td>
+
+Capture an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">amount</td>
+<td valign="top"><a href="#decimal">Decimal</a>!</td>
+<td>
+
+Amount of money to capture.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to capture.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderFulfillmentCancel</strong></td>
+<td valign="top"><a href="#fulfillmentcancel">FulfillmentCancel</a></td>
+<td>
+
+Cancels existing fulfillment
+        and optionally restocks items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an fulfillment to cancel.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#fulfillmentcancelinput">FulfillmentCancelInput</a>!</td>
+<td>
+
+Fields required to cancel an fulfillment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderFulfillmentCreate</strong></td>
+<td valign="top"><a href="#fulfillmentcreate">FulfillmentCreate</a></td>
+<td>
+
+Creates a new fulfillment for an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#fulfillmentcreateinput">FulfillmentCreateInput</a>!</td>
+<td>
+
+Fields required to create an fulfillment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">order</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the order to be fulfilled.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderFulfillmentUpdateTracking</strong></td>
+<td valign="top"><a href="#fulfillmentupdatetracking">FulfillmentUpdateTracking</a></td>
+<td>
+
+Updates a fulfillment for an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an fulfillment to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#fulfillmentupdatetrackinginput">FulfillmentUpdateTrackingInput</a>!</td>
+<td>
+
+Fields required to update an fulfillment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderMarkAsPaid</strong></td>
+<td valign="top"><a href="#ordermarkaspaid">OrderMarkAsPaid</a></td>
+<td>
+
+Mark order as manually paid.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to mark paid.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderRefund</strong></td>
+<td valign="top"><a href="#orderrefund">OrderRefund</a></td>
+<td>
+
+Refund an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">amount</td>
+<td valign="top"><a href="#decimal">Decimal</a>!</td>
+<td>
+
+Amount of money to refund.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to refund.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderUpdate</strong></td>
+<td valign="top"><a href="#orderupdate">OrderUpdate</a></td>
+<td>
+
+Updates an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an order to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#orderupdateinput">OrderUpdateInput</a>!</td>
+<td>
+
+Fields required to update an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderUpdateShipping</strong></td>
+<td valign="top"><a href="#orderupdateshipping">OrderUpdateShipping</a></td>
+<td>
+
+Updates a shipping method of the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">order</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to update a shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#orderupdateshippinginput">OrderUpdateShippingInput</a></td>
+<td>
+
+Fields required to change shipping method of the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderVoid</strong></td>
+<td valign="top"><a href="#ordervoid">OrderVoid</a></td>
+<td>
+
+Void an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the order to void.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderBulkCancel</strong></td>
+<td valign="top"><a href="#orderbulkcancel">OrderBulkCancel</a></td>
+<td>
+
+Cancels orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of orders IDs to cancel.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">restock</td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Determine if lines will be restocked or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>assignNavigation</strong></td>
+<td valign="top"><a href="#assignnavigation">AssignNavigation</a></td>
+<td>
+
+Assigns storefront's navigation menus.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">menu</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">navigationType</td>
+<td valign="top"><a href="#navigationtype">NavigationType</a>!</td>
+<td>
+
+Type of the navigation bar to assign the menu to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuCreate</strong></td>
+<td valign="top"><a href="#menucreate">MenuCreate</a></td>
+<td>
+
+Creates a new Menu
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#menucreateinput">MenuCreateInput</a>!</td>
+<td>
+
+Fields required to create a menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuDelete</strong></td>
+<td valign="top"><a href="#menudelete">MenuDelete</a></td>
+<td>
+
+Deletes a menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a menu to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuBulkDelete</strong></td>
+<td valign="top"><a href="#menubulkdelete">MenuBulkDelete</a></td>
+<td>
+
+Deletes menus.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of menu IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuUpdate</strong></td>
+<td valign="top"><a href="#menuupdate">MenuUpdate</a></td>
+<td>
+
+Updates a menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a menu to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#menuinput">MenuInput</a>!</td>
+<td>
+
+Fields required to update a menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItemCreate</strong></td>
+<td valign="top"><a href="#menuitemcreate">MenuItemCreate</a></td>
+<td>
+
+Creates a new menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#menuitemcreateinput">MenuItemCreateInput</a>!</td>
+<td>
+
+Fields required to update a menu item.
+            Only one of 'url', 'category', 'page', 'collection' is allowed
+            per item
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItemDelete</strong></td>
+<td valign="top"><a href="#menuitemdelete">MenuItemDelete</a></td>
+<td>
+
+Deletes a menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a menu item to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItemBulkDelete</strong></td>
+<td valign="top"><a href="#menuitembulkdelete">MenuItemBulkDelete</a></td>
+<td>
+
+Deletes menu items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of menu item IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItemUpdate</strong></td>
+<td valign="top"><a href="#menuitemupdate">MenuItemUpdate</a></td>
+<td>
+
+Updates a menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a menu item to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#menuiteminput">MenuItemInput</a>!</td>
+<td>
+
+Fields required to update a menu item.
+            Only one of 'url', 'category', 'page', 'collection' is allowed
+            per item
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItemTranslate</strong></td>
+<td valign="top"><a href="#menuitemtranslate">MenuItemTranslate</a></td>
+<td>
+
+Creates/Updates translations for Menu Item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Menu Item ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItemMove</strong></td>
+<td valign="top"><a href="#menuitemmove">MenuItemMove</a></td>
+<td>
+
+Moves items of menus
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">menu</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">moves</td>
+<td valign="top">[<a href="#menuitemmoveinput">MenuItemMoveInput</a>]!</td>
+<td>
+
+The menu position data
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardActivate</strong></td>
+<td valign="top"><a href="#giftcardactivate">GiftCardActivate</a></td>
+<td>
+
+Activate a gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a gift card to activate.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardCreate</strong></td>
+<td valign="top"><a href="#giftcardcreate">GiftCardCreate</a></td>
+<td>
+
+Creates a new gift card
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#giftcardcreateinput">GiftCardCreateInput</a>!</td>
+<td>
+
+Fields required to create a gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardDeactivate</strong></td>
+<td valign="top"><a href="#giftcarddeactivate">GiftCardDeactivate</a></td>
+<td>
+
+Deactivate a gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a gift card to deactivate.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardUpdate</strong></td>
+<td valign="top"><a href="#giftcardupdate">GiftCardUpdate</a></td>
+<td>
+
+Update a gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a gift card to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#giftcardupdateinput">GiftCardUpdateInput</a>!</td>
+<td>
+
+Fields required to update a gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pluginUpdate</strong></td>
+<td valign="top"><a href="#pluginupdate">PluginUpdate</a></td>
+<td>
+
+Update plugin configuration
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of plugin to update
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#pluginupdateinput">PluginUpdateInput</a>!</td>
+<td>
+
+Fields required to update a plugin configuration.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleCreate</strong></td>
+<td valign="top"><a href="#salecreate">SaleCreate</a></td>
+<td>
+
+Creates a new sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#saleinput">SaleInput</a>!</td>
+<td>
+
+Fields required to create a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleDelete</strong></td>
+<td valign="top"><a href="#saledelete">SaleDelete</a></td>
+<td>
+
+Deletes a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a sale to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleBulkDelete</strong></td>
+<td valign="top"><a href="#salebulkdelete">SaleBulkDelete</a></td>
+<td>
+
+Deletes sales.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of sale IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleUpdate</strong></td>
+<td valign="top"><a href="#saleupdate">SaleUpdate</a></td>
+<td>
+
+Updates a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a sale to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#saleinput">SaleInput</a>!</td>
+<td>
+
+Fields required to update a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleCataloguesAdd</strong></td>
+<td valign="top"><a href="#saleaddcatalogues">SaleAddCatalogues</a></td>
+<td>
+
+Adds products, categories, collections to a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#catalogueinput">CatalogueInput</a>!</td>
+<td>
+
+Fields required to modify catalogue IDs of sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleCataloguesRemove</strong></td>
+<td valign="top"><a href="#saleremovecatalogues">SaleRemoveCatalogues</a></td>
+<td>
+
+Removes products, categories, collections from a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#catalogueinput">CatalogueInput</a>!</td>
+<td>
+
+Fields required to modify catalogue IDs of sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleTranslate</strong></td>
+<td valign="top"><a href="#saletranslate">SaleTranslate</a></td>
+<td>
+
+Creates/updates translations for a sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Voucher ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherCreate</strong></td>
+<td valign="top"><a href="#vouchercreate">VoucherCreate</a></td>
+<td>
+
+Creates a new voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#voucherinput">VoucherInput</a>!</td>
+<td>
+
+Fields required to create a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherDelete</strong></td>
+<td valign="top"><a href="#voucherdelete">VoucherDelete</a></td>
+<td>
+
+Deletes a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a voucher to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherBulkDelete</strong></td>
+<td valign="top"><a href="#voucherbulkdelete">VoucherBulkDelete</a></td>
+<td>
+
+Deletes vouchers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of voucher IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherUpdate</strong></td>
+<td valign="top"><a href="#voucherupdate">VoucherUpdate</a></td>
+<td>
+
+Updates a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a voucher to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#voucherinput">VoucherInput</a>!</td>
+<td>
+
+Fields required to update a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherCataloguesAdd</strong></td>
+<td valign="top"><a href="#voucheraddcatalogues">VoucherAddCatalogues</a></td>
+<td>
+
+Adds products, categories, collections to a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#catalogueinput">CatalogueInput</a>!</td>
+<td>
+
+Fields required to modify catalogue IDs of voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherCataloguesRemove</strong></td>
+<td valign="top"><a href="#voucherremovecatalogues">VoucherRemoveCatalogues</a></td>
+<td>
+
+Removes products, categories, collections from a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#catalogueinput">CatalogueInput</a>!</td>
+<td>
+
+Fields required to modify catalogue IDs of voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherTranslate</strong></td>
+<td valign="top"><a href="#vouchertranslate">VoucherTranslate</a></td>
+<td>
+
+Creates/Updates translations for Voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Voucher ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#nametranslationinput">NameTranslationInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Translation language code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>tokenCreate</strong></td>
+<td valign="top"><a href="#createtoken">CreateToken</a></td>
+<td>
+
+Mutation that authenticates a user and returns token and user data.
+
+It overrides the default graphql_jwt.ObtainJSONWebToken to wrap potential
+authentication errors in our Error type, which is consistent to how rest of
+the mutation works.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">password</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>tokenRefresh</strong></td>
+<td valign="top"><a href="#refresh">Refresh</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>tokenVerify</strong></td>
+<td valign="top"><a href="#verifytoken">VerifyToken</a></td>
+<td>
+
+Mutation that confirm if token is valid and also return user data.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutAddPromoCode</strong></td>
+<td valign="top"><a href="#checkoutaddpromocode">CheckoutAddPromoCode</a></td>
+<td>
+
+Adds a gift card or a voucher to a checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">promoCode</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Gift card code or voucher code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutBillingAddressUpdate</strong></td>
+<td valign="top"><a href="#checkoutbillingaddressupdate">CheckoutBillingAddressUpdate</a></td>
+<td>
+
+Update billing address in the existing Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">billingAddress</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+The billing address of the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutComplete</strong></td>
+<td valign="top"><a href="#checkoutcomplete">CheckoutComplete</a></td>
+<td>
+
+Completes the checkout. As a result a new order is created and a payment charge is made. This action requires a successful payment before it can be performed.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">storeSource</td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines whether to store the payment source for future usage.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutCreate</strong></td>
+<td valign="top"><a href="#checkoutcreate">CheckoutCreate</a></td>
+<td>
+
+Create a new checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#checkoutcreateinput">CheckoutCreateInput</a>!</td>
+<td>
+
+Fields required to create checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutCustomerAttach</strong></td>
+<td valign="top"><a href="#checkoutcustomerattach">CheckoutCustomerAttach</a></td>
+<td>
+
+Sets the customer as the owner of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">customerId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutCustomerDetach</strong></td>
+<td valign="top"><a href="#checkoutcustomerdetach">CheckoutCustomerDetach</a></td>
+<td>
+
+Removes the user assigned as the owner of the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutEmailUpdate</strong></td>
+<td valign="top"><a href="#checkoutemailupdate">CheckoutEmailUpdate</a></td>
+<td>
+
+Updates email address in the existing Checkout object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+email
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutLineDelete</strong></td>
+<td valign="top"><a href="#checkoutlinedelete">CheckoutLineDelete</a></td>
+<td>
+
+Deletes a CheckoutLine.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">lineId</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the CheckoutLine to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutLinesAdd</strong></td>
+<td valign="top"><a href="#checkoutlinesadd">CheckoutLinesAdd</a></td>
+<td>
+
+Adds a checkout line to the existing checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">lines</td>
+<td valign="top">[<a href="#checkoutlineinput">CheckoutLineInput</a>]!</td>
+<td>
+
+A list of checkout lines, each containing information about an item in the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutLinesUpdate</strong></td>
+<td valign="top"><a href="#checkoutlinesupdate">CheckoutLinesUpdate</a></td>
+<td>
+
+Updates CheckoutLine in the existing Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">lines</td>
+<td valign="top">[<a href="#checkoutlineinput">CheckoutLineInput</a>]!</td>
+<td>
+
+A list of checkout lines, each containing information about an item in the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutRemovePromoCode</strong></td>
+<td valign="top"><a href="#checkoutremovepromocode">CheckoutRemovePromoCode</a></td>
+<td>
+
+Remove a gift card or a voucher from a checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">promoCode</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Gift card code or voucher code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutPaymentCreate</strong></td>
+<td valign="top"><a href="#checkoutpaymentcreate">CheckoutPaymentCreate</a></td>
+<td>
+
+Create a new payment for given checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Checkout ID.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#paymentinput">PaymentInput</a>!</td>
+<td>
+
+Data required to create a new payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutShippingAddressUpdate</strong></td>
+<td valign="top"><a href="#checkoutshippingaddressupdate">CheckoutShippingAddressUpdate</a></td>
+<td>
+
+Update shipping address in the existing Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">shippingAddress</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+The mailing address to where the checkout will be shipped.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutShippingMethodUpdate</strong></td>
+<td valign="top"><a href="#checkoutshippingmethodupdate">CheckoutShippingMethodUpdate</a></td>
+<td>
+
+Updates the shipping address of the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">shippingMethodId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Shipping method
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutUpdateVoucher</strong></td>
+<td valign="top"><a href="#checkoutupdatevoucher">CheckoutUpdateVoucher</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use CheckoutAddPromoCode or CheckoutRemovePromoCode instead. Adds voucher to the checkout. Query it without voucher_code field to remove voucher from checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">checkoutId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Checkout ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">voucherCode</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Voucher code
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutUpdateMetadata</strong></td>
+<td valign="top"><a href="#checkoutupdatemeta">CheckoutUpdateMeta</a></td>
+<td>
+
+Updates metadata for Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutClearMetadata</strong></td>
+<td valign="top"><a href="#checkoutclearstoredmeta">CheckoutClearStoredMeta</a></td>
+<td>
+
+Clear stored metadata value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#checkoutupdateprivatemeta">CheckoutUpdatePrivateMeta</a></td>
+<td>
+
+Updates private metadata for Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutClearPrivateMetadata</strong></td>
+<td valign="top"><a href="#checkoutclearstoredprivatemeta">CheckoutClearStoredPrivateMeta</a></td>
+<td>
+
+Clear stored metadata value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>requestPasswordReset</strong></td>
+<td valign="top"><a href="#requestpasswordreset">RequestPasswordReset</a></td>
+<td>
+
+Sends an email with the account password modification link.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Email of the user that will be used for password recovery.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">redirectUrl</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+('URL of a view where users should be redirected to reset the password. URL in RFC 1808 format.',)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>setPassword</strong></td>
+<td valign="top"><a href="#setpassword">SetPassword</a></td>
+<td>
+
+Sets the user's password from the token sent by email using the RequestPasswordReset mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A one-time token required to set the password.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">password</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>passwordChange</strong></td>
+<td valign="top"><a href="#passwordchange">PasswordChange</a></td>
+<td>
+
+Change the password of the logged in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">newPassword</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+New user password.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">oldPassword</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Current user password.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userUpdateMetadata</strong></td>
+<td valign="top"><a href="#userupdatemeta">UserUpdateMeta</a></td>
+<td>
+
+Updates metadata for user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userClearStoredMetadata</strong></td>
+<td valign="top"><a href="#userclearstoredmeta">UserClearStoredMeta</a></td>
+<td>
+
+Clear stored metadata value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountAddressCreate</strong></td>
+<td valign="top"><a href="#accountaddresscreate">AccountAddressCreate</a></td>
+<td>
+
+Create a new address for the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+Fields required to create address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#addresstypeenum">AddressTypeEnum</a></td>
+<td>
+
+A type of address. If provided, the new address will be automatically assigned as the customer's default address of that type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountAddressUpdate</strong></td>
+<td valign="top"><a href="#accountaddressupdate">AccountAddressUpdate</a></td>
+<td>
+
+Updates an address of the logged-in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address to update
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+Fields required to update the address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountAddressDelete</strong></td>
+<td valign="top"><a href="#accountaddressdelete">AccountAddressDelete</a></td>
+<td>
+
+Delete an address of the logged-in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountSetDefaultAddress</strong></td>
+<td valign="top"><a href="#accountsetdefaultaddress">AccountSetDefaultAddress</a></td>
+<td>
+
+Sets a default address for the authenticated user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address to set as default.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#addresstypeenum">AddressTypeEnum</a>!</td>
+<td>
+
+The type of address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountRegister</strong></td>
+<td valign="top"><a href="#accountregister">AccountRegister</a></td>
+<td>
+
+Register a new user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#accountregisterinput">AccountRegisterInput</a>!</td>
+<td>
+
+Fields required to create a user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountUpdate</strong></td>
+<td valign="top"><a href="#accountupdate">AccountUpdate</a></td>
+<td>
+
+Updates the account of the logged-in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#accountinput">AccountInput</a>!</td>
+<td>
+
+Fields required to update the account of the logged-in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountRequestDeletion</strong></td>
+<td valign="top"><a href="#accountrequestdeletion">AccountRequestDeletion</a></td>
+<td>
+
+Sends an email with the account removal link for the logged-in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">redirectUrl</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+('URL of a view where users should be redirected to delete their account. URL in RFC 1808 format.',)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountDelete</strong></td>
+<td valign="top"><a href="#accountdelete">AccountDelete</a></td>
+<td>
+
+Remove user account.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A one-time token required to remove account. Sent by email using AccountRequestDeletion mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerPasswordReset</strong></td>
+<td valign="top"><a href="#customerpasswordreset">CustomerPasswordReset</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use RequestPasswordReset instead. Resets the customer's password.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#customerpasswordresetinput">CustomerPasswordResetInput</a>!</td>
+<td>
+
+Fields required to reset customer's password
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerAddressCreate</strong></td>
+<td valign="top"><a href="#customeraddresscreate">CustomerAddressCreate</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountAddressCreate instead. Create a new address for the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+Fields required to create address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#addresstypeenum">AddressTypeEnum</a></td>
+<td>
+
+A type of address. If provided, the new address will be automatically assigned as the customer's default address of that type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerSetDefaultAddress</strong></td>
+<td valign="top"><a href="#customersetdefaultaddress">CustomerSetDefaultAddress</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountSetDefaultAddress instead. Sets a default address for the authenticated user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address to set as default.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#addresstypeenum">AddressTypeEnum</a>!</td>
+<td>
+
+The type of address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerRegister</strong></td>
+<td valign="top"><a href="#customerregister">CustomerRegister</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountRegister instead. Register a new user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#customerregisterinput">CustomerRegisterInput</a>!</td>
+<td>
+
+Fields required to create a user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>loggedUserUpdate</strong></td>
+<td valign="top"><a href="#loggeduserupdate">LoggedUserUpdate</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountUpdate instead.Updates data of the logged in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#useraddressinput">UserAddressInput</a>!</td>
+<td>
+
+Fields required to update a logged in user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressCreate</strong></td>
+<td valign="top"><a href="#addresscreate">AddressCreate</a></td>
+<td>
+
+Creates user address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+Fields required to create address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">userId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a user to create address for
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressUpdate</strong></td>
+<td valign="top"><a href="#addressupdate">AddressUpdate</a></td>
+<td>
+
+Updates an address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address to update
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#addressinput">AddressInput</a>!</td>
+<td>
+
+Fields required to update the address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressDelete</strong></td>
+<td valign="top"><a href="#addressdelete">AddressDelete</a></td>
+<td>
+
+Deletes an address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressSetDefault</strong></td>
+<td valign="top"><a href="#addresssetdefault">AddressSetDefault</a></td>
+<td>
+
+Sets a default address for the given user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">addressId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#addresstypeenum">AddressTypeEnum</a>!</td>
+<td>
+
+The type of address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">userId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the user to change the address for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerCreate</strong></td>
+<td valign="top"><a href="#customercreate">CustomerCreate</a></td>
+<td>
+
+Creates a new customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#usercreateinput">UserCreateInput</a>!</td>
+<td>
+
+Fields required to create a customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerUpdate</strong></td>
+<td valign="top"><a href="#customerupdate">CustomerUpdate</a></td>
+<td>
+
+Updates an existing customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#customerinput">CustomerInput</a>!</td>
+<td>
+
+Fields required to update a customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerDelete</strong></td>
+<td valign="top"><a href="#customerdelete">CustomerDelete</a></td>
+<td>
+
+Deletes a customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerBulkDelete</strong></td>
+<td valign="top"><a href="#customerbulkdelete">CustomerBulkDelete</a></td>
+<td>
+
+Deletes customers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of sale IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>staffCreate</strong></td>
+<td valign="top"><a href="#staffcreate">StaffCreate</a></td>
+<td>
+
+Creates a new staff user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#staffcreateinput">StaffCreateInput</a>!</td>
+<td>
+
+Fields required to create a staff user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>staffUpdate</strong></td>
+<td valign="top"><a href="#staffupdate">StaffUpdate</a></td>
+<td>
+
+Updates an existing staff user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a staff user to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#staffinput">StaffInput</a>!</td>
+<td>
+
+Fields required to update a staff user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>staffDelete</strong></td>
+<td valign="top"><a href="#staffdelete">StaffDelete</a></td>
+<td>
+
+Deletes a staff user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a staff user to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>staffBulkDelete</strong></td>
+<td valign="top"><a href="#staffbulkdelete">StaffBulkDelete</a></td>
+<td>
+
+Deletes staff users.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of sale IDs to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userAvatarUpdate</strong></td>
+<td valign="top"><a href="#useravatarupdate">UserAvatarUpdate</a></td>
+<td>
+
+
+            Create a user avatar. Only for staff members. This mutation must
+            be sent as a `multipart` request. More detailed specs of the
+            upload format can be found here:
+            https://github.com/jaydenseric/graphql-multipart-request-spec
+            
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">image</td>
+<td valign="top"><a href="#upload">Upload</a>!</td>
+<td>
+
+Represents an image file in a multipart request.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userAvatarDelete</strong></td>
+<td valign="top"><a href="#useravatardelete">UserAvatarDelete</a></td>
+<td>
+
+Deletes a user avatar. Only for staff members.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userBulkSetActive</strong></td>
+<td valign="top"><a href="#userbulksetactive">UserBulkSetActive</a></td>
+<td>
+
+Activate or deactivate users.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">ids</td>
+<td valign="top">[<a href="#id">ID</a>]!</td>
+<td>
+
+List of user IDs to (de)activate).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">isActive</td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Determine if users will be set active or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#userupdateprivatemeta">UserUpdatePrivateMeta</a></td>
+<td>
+
+Updates private metadata for user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userClearStoredPrivateMetadata</strong></td>
+<td valign="top"><a href="#userclearstoredprivatemeta">UserClearStoredPrivateMeta</a></td>
+<td>
+
+Clear stored metadata value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccountCreate</strong></td>
+<td valign="top"><a href="#serviceaccountcreate">ServiceAccountCreate</a></td>
+<td>
+
+Creates a new service account
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#serviceaccountinput">ServiceAccountInput</a>!</td>
+<td>
+
+Fields required to create a new service account.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccountUpdate</strong></td>
+<td valign="top"><a href="#serviceaccountupdate">ServiceAccountUpdate</a></td>
+<td>
+
+Updates an existing service account
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a service account to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#serviceaccountinput">ServiceAccountInput</a>!</td>
+<td>
+
+Fields required to update an existing service account.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccountDelete</strong></td>
+<td valign="top"><a href="#serviceaccountdelete">ServiceAccountDelete</a></td>
+<td>
+
+Deletes a service account
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a service account to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccountUpdatePrivateMetadata</strong></td>
+<td valign="top"><a href="#serviceaccountupdateprivatemeta">ServiceAccountUpdatePrivateMeta</a></td>
+<td>
+
+Updates private metadata for a service account.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an object to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metainput">MetaInput</a>!</td>
+<td>
+
+Fields required to update new or stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccountClearStoredPrivateMetadata</strong></td>
+<td valign="top"><a href="#serviceaccountclearstoredprivatemeta">ServiceAccountClearStoredPrivateMeta</a></td>
+<td>
+
+Clear stored metadata value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of a customer to update.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#metapath">MetaPath</a>!</td>
+<td>
+
+Fields required to identify stored metadata item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>passwordReset</strong></td>
+<td valign="top"><a href="#passwordreset">PasswordReset</a></td>
+<td>
+
+DEPRECATED: Will be removed in Saleor 2.10, use RequestPasswordReset instead. Sends an email with the account password change link to customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Email
+
+</td>
+</tr>
+</tbody>
+</table>
+
+## Objects
+
+### AccountAddressCreate
+
+Create a new address for the customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user instance for which the address was created.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountAddressDelete
+
+Delete an address of the logged-in user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user instance for which the address was deleted.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountAddressUpdate
+
+Updates an address of the logged-in user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user object for which the address was edited.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountDelete
+
+Remove user account.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#accounterrorcode">AccountErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AccountRegister
+
+Register a new user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountRequestDeletion
+
+Sends an email with the account removal link for the logged-in user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountSetDefaultAddress
+
+Sets a default address for the authenticated user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+An updated user instance.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AccountUpdate
+
+Updates the account of the logged-in user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Address
+
+Represents user address data.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>streetAddress1</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>streetAddress2</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>city</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cityArea</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>postalCode</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>country</strong></td>
+<td valign="top"><a href="#countrydisplay">CountryDisplay</a>!</td>
+<td>
+
+Default shop's country
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countryArea</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isDefaultShippingAddress</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Address is user's default shipping address
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isDefaultBillingAddress</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Address is user's default billing address
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AddressCreate
+
+Creates user address
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user instance for which the address was created.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AddressDelete
+
+Deletes an address
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user instance for which the address was deleted.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AddressSetDefault
+
+Sets a default address for the given user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+An updated user instance.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AddressUpdate
+
+Updates an address
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user object for which the address was edited.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AddressValidationData
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>countryCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countryName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressFormat</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addressLatinFormat</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>allowedFields</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>requiredFields</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>upperFields</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countryAreaType</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countryAreaChoices</strong></td>
+<td valign="top">[<a href="#choicevalue">ChoiceValue</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cityType</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cityChoices</strong></td>
+<td valign="top">[<a href="#choicevalue">ChoiceValue</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cityAreaType</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cityAreaChoices</strong></td>
+<td valign="top">[<a href="#choicevalue">ChoiceValue</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>postalCodeType</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>postalCodeMatchers</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>postalCodeExamples</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>postalCodePrefix</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AssignNavigation
+
+Assigns storefront's navigation menus.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td>
+
+Assigned navigation menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Attribute
+
+
+            Custom attribute of a product. Attributes can be
+            assigned to products and variants at the product type level.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productTypes</strong></td>
+<td valign="top"><a href="#producttypecountableconnection">ProductTypeCountableConnection</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariantTypes</strong></td>
+<td valign="top"><a href="#producttypecountableconnection">ProductTypeCountableConnection</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>inputType</strong></td>
+<td valign="top"><a href="#attributeinputtypeenum">AttributeInputTypeEnum</a></td>
+<td>
+
+The input type to use for entering attribute values in the dashboard.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of an attribute displayed in the interface.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Internal representation of an attribute name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>values</strong></td>
+<td valign="top">[<a href="#attributevalue">AttributeValue</a>]</td>
+<td>
+
+List of attribute's values.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>valueRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Whether the attribute requires values to be passed or not
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>visibleInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Whether the attribute should be visible or not in storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Whether the attribute can be filtered in storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInDashboard</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Whether the attribute can be filtered in dashboard
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableInGrid</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Whether the attribute can be displayed in the admin product list
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#attributetranslation">AttributeTranslation</a></td>
+<td>
+
+Returns translated Attribute fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>storefrontSearchPosition</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+The position of the attribute in the storefront navigation (0 by default)
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeAssign
+
+Assign attributes to a given product type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td>
+
+The updated product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeBulkDelete
+
+Deletes attributes.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeClearMeta
+
+Clears public metadata item for Attribute
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeClearPrivateMeta
+
+Clears public metadata item for Attribute
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#attributecountableedge">AttributeCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeCreate
+
+Creates an attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeDelete
+
+Deletes an attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeReorderValues
+
+Reorder the values of an attribute
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td>
+
+Attribute from which values are reordered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeTranslate
+
+Creates/Updates translations for Attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeUnassign
+
+Un-assign attributes from a given product type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td>
+
+The updated product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeUpdate
+
+Updates attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeUpdateMeta
+
+Update public metadata for Attribute 
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeUpdatePrivateMeta
+
+Update public metadata for Attribute
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValue
+
+Represents a value of an attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a value displayed in the interface.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Internal representation of a value (unique per attribute).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#attributevaluetype">AttributeValueType</a></td>
+<td>
+
+Type of value (used only when `value` field is set).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#attributevaluetranslation">AttributeValueTranslation</a></td>
+<td>
+
+Returns translated Attribute Value fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>inputType</strong></td>
+<td valign="top"><a href="#attributeinputtypeenum">AttributeInputTypeEnum</a></td>
+<td>
+
+The input type to use for entering attribute values in the dashboard.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueBulkDelete
+
+Deletes values of attributes.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueCreate
+
+Creates a value for an attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td>
+
+The updated attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValue</strong></td>
+<td valign="top"><a href="#attributevalue">AttributeValue</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueDelete
+
+Deletes a value of an attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td>
+
+The updated attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValue</strong></td>
+<td valign="top"><a href="#attributevalue">AttributeValue</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueTranslate
+
+Creates/Updates translations for Attribute Value.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValue</strong></td>
+<td valign="top"><a href="#attributevalue">AttributeValue</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueUpdate
+
+Updates value of an attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a></td>
+<td>
+
+The updated attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeValue</strong></td>
+<td valign="top"><a href="#attributevalue">AttributeValue</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AuthorizationKey
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#authorizationkeytype">AuthorizationKeyType</a>!</td>
+<td>
+
+Name of the authorization backend.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>key</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Authorization key (client ID).
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AuthorizationKeyAdd
+
+Adds an authorization key.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>authorizationKey</strong></td>
+<td valign="top"><a href="#authorizationkey">AuthorizationKey</a></td>
+<td>
+
+Newly added authorization key.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AuthorizationKeyDelete
+
+Deletes an authorization key.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>authorizationKey</strong></td>
+<td valign="top"><a href="#authorizationkey">AuthorizationKey</a></td>
+<td>
+
+Authorization key that was deleted.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Category
+
+Represents a single category of products.
+        Categories allow to organize products in a tree-hierarchies which can
+        be used for navigation in the storefront.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>parent</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>level</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>ancestors</strong></td>
+<td valign="top"><a href="#categorycountableconnection">CategoryCountableConnection</a></td>
+<td>
+
+List of ancestors of the category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top"><a href="#productcountableconnection">ProductCountableConnection</a></td>
+<td>
+
+List of products in the category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The storefront's URL for the category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>children</strong></td>
+<td valign="top"><a href="#categorycountableconnection">CategoryCountableConnection</a></td>
+<td>
+
+List of children of the category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImage</strong></td>
+<td valign="top"><a href="#image">Image</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">size</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Size of the image
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#categorytranslation">CategoryTranslation</a></td>
+<td>
+
+Returns translated Category fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CategoryBulkDelete
+
+Deletes categories.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryClearMeta
+
+Clears public metadata item for category
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryClearPrivateMeta
+
+Clears public metadata item for category
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#categorycountableedge">CategoryCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CategoryCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#category">Category</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CategoryCreate
+
+Creates a new category.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryDelete
+
+Deletes a category.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryTranslate
+
+Creates/Updates translations for Category.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CategoryUpdate
+
+Updates a category.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryUpdateMeta
+
+Update public metadata for category
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryUpdatePrivateMeta
+
+Update public metadata for category
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Checkout
+
+Checkout object
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastChange</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#uuid">UUID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#shippingmethod">ShippingMethod</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>note</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountAmount</strong> ⚠️</td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, use discount instead.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discount</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translatedDiscountName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucherCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCards</strong></td>
+<td valign="top">[<a href="#giftcard">GiftCard</a>]</td>
+<td>
+
+List of gift cards associated with this checkout
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableShippingMethods</strong></td>
+<td valign="top">[<a href="#shippingmethod">ShippingMethod</a>]!</td>
+<td>
+
+Shipping methods that can be used with this order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availablePaymentGateways</strong></td>
+<td valign="top">[<a href="#gatewaysenum">GatewaysEnum</a>]!</td>
+<td>
+
+List of available payment gateways.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Email of a customer
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isShippingRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Returns True, if checkout requires shipping.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#checkoutline">CheckoutLine</a>]</td>
+<td>
+
+A list of checkout lines, each containing information about an item in the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPrice</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The price of the shipping, with all the taxes included.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>subtotalPrice</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The price of the checkout before shipping, with taxes included.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalPrice</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The sum of the the checkout line prices, with all the taxes,shipping costs, and discounts included.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutAddPromoCode
+
+Adds a gift card or a voucher to a checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+The checkout with the added gift card or voucher
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutBillingAddressUpdate
+
+Update billing address in the existing Checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutClearStoredMeta
+
+Clear stored metadata value.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutClearStoredPrivateMeta
+
+Clear stored metadata value.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutComplete
+
+Completes the checkout. As a result a new order is created and a payment charge is made. This action requires a successful payment before it can be performed.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Placed order
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#checkoutcountableedge">CheckoutCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutCreate
+
+Create a new checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the checkout was created or the current active one was returned. Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart with an active checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutCustomerAttach
+
+Sets the customer as the owner of the Checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutCustomerDetach
+
+Removes the user assigned as the owner of the checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutEmailUpdate
+
+Updates email address in the existing Checkout object.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#checkouterrorcode">CheckoutErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLine
+
+Represents an item in the checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalPrice</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The sum of the checkout line price, taxes and discounts.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>requiresShipping</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Indicates whether the item need to be delivered.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLineCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#checkoutlinecountableedge">CheckoutLineCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLineCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#checkoutline">CheckoutLine</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLineDelete
+
+Deletes a CheckoutLine.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLinesAdd
+
+Adds a checkout line to the existing checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLinesUpdate
+
+Updates CheckoutLine in the existing Checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated Checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutPaymentCreate
+
+Create a new payment for given checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+Related checkout object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a></td>
+<td>
+
+A newly created payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentErrors</strong></td>
+<td valign="top">[<a href="#paymenterror">PaymentError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutRemovePromoCode
+
+Remove a gift card or a voucher from a checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+The checkout with the removed gift card or voucher
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutShippingAddressUpdate
+
+Update shipping address in the existing Checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutShippingMethodUpdate
+
+Updates the shipping address of the checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An updated checkout
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutUpdateMeta
+
+Updates metadata for Checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutUpdatePrivateMeta
+
+Updates private metadata for Checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutUpdateVoucher
+
+DEPRECATED: Will be removed in Saleor 2.10, use CheckoutAddPromoCode or CheckoutRemovePromoCode instead. Adds voucher to the checkout. Query it without voucher_code field to remove voucher from checkout.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+An checkout with updated voucher
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkoutErrors</strong></td>
+<td valign="top">[<a href="#checkouterror">CheckoutError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ChoiceValue
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>raw</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>verbose</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Collection
+
+Represents a collection of products.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top"><a href="#productcountableconnection">ProductCountableConnection</a></td>
+<td>
+
+List of products in this collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImage</strong></td>
+<td valign="top"><a href="#image">Image</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">size</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Size of the image
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#collectiontranslation">CollectionTranslation</a></td>
+<td>
+
+Returns translated Collection fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CollectionAddProducts
+
+Adds products to a collection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td>
+
+Collection to which products will be added.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionBulkDelete
+
+Deletes collections.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionBulkPublish
+
+Publish collections.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionClearMeta
+
+Clears public metadata item for Collection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionClearPrivateMeta
+
+Clears public metadata item for Collection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#collectioncountableedge">CollectionCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CollectionCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#collection">Collection</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CollectionCreate
+
+Creates a new collection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionDelete
+
+Deletes a collection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionRemoveProducts
+
+Remove products from a collection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td>
+
+Collection from which products will be removed.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionReorderProducts
+
+Reorder the products of a collection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td>
+
+Collection from which products are reordered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionTranslate
+
+Creates/Updates translations for Collection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CollectionUpdate
+
+Updates a collection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionUpdateMeta
+
+Update public metadata for Collection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionUpdatePrivateMeta
+
+Update public metadata for Collection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ConfigurationItem
+
+Stores information about single configuration field
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of the field
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Current value of the field
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#configurationtypefieldenum">ConfigurationTypeFieldEnum</a></td>
+<td>
+
+Type of the field
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>helpText</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Help text for the field
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>label</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Label for the field
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CountryDisplay
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Country code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>country</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Country name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>vat</strong></td>
+<td valign="top"><a href="#vat">VAT</a></td>
+<td>
+
+Country tax.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CreateToken
+
+Mutation that authenticates a user and returns token and user data.
+
+It overrides the default graphql_jwt.ObtainJSONWebToken to wrap potential
+authentication errors in our Error type, which is consistent to how rest of
+the mutation works.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CreditCard
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>brand</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Card brand.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>firstDigits</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The host name of the domain.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastDigits</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Last 4 digits of the card number.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>expMonth</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Two-digit number representing the card’s expiration month.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>expYear</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Four-digit number representing the card’s expiration year.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerAddressCreate
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountAddressCreate instead. Create a new address for the customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user instance for which the address was created.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerBulkDelete
+
+Deletes customers.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerCreate
+
+Creates a new customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerDelete
+
+Deletes a customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerEvent
+
+History log of the customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>date</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+Date when event happened at in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#customereventsenum">CustomerEventsEnum</a></td>
+<td>
+
+Customer event type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+User who performed the action.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Content of the event.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Number of objects concerned by the event.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+The concerned order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderLine</strong></td>
+<td valign="top"><a href="#orderline">OrderLine</a></td>
+<td>
+
+The concerned order line.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerPasswordReset
+
+DEPRECATED: Will be removed in Saleor 2.10, use RequestPasswordReset instead. Resets the customer's password.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerRegister
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountRegister instead. Register a new user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerSetDefaultAddress
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountSetDefaultAddress instead. Sets a default address for the authenticated user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+An updated user instance.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerUpdate
+
+Updates an existing customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContent
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>useDefaultSettings</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>automaticFulfillment</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contentFile</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maxDownloads</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>urlValidDays</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>urls</strong></td>
+<td valign="top">[<a href="#digitalcontenturl">DigitalContentUrl</a>]</td>
+<td>
+
+List of urls for the digital variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#digitalcontentcountableedge">DigitalContentCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#digitalcontent">DigitalContent</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentCreate
+
+Create new digital content. This mutation must
+        be sent as a `multipart` request. More detailed specs of the upload
+        format can be found here:
+        https://github.com/jaydenseric/graphql-multipart-request-spec
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#digitalcontent">DigitalContent</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentDelete
+
+Remove digital content assigned to given variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentUpdate
+
+Update digital content
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#digitalcontent">DigitalContent</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentUrl
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#uuid">UUID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#digitalcontent">DigitalContent</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>downloadNum</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Url for digital content
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentUrlCreate
+
+Generate new url to digital content
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContentUrl</strong></td>
+<td valign="top"><a href="#digitalcontenturl">DigitalContentUrl</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Domain
+
+Represents shop's domain.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>host</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The host name of the domain.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sslEnabled</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Inform if SSL is enabled.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Shop's absolute URL.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderBulkDelete
+
+Deletes draft orders.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderComplete
+
+Completes creating an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Completed order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderCreate
+
+Creates a new draft order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderDelete
+
+Deletes a draft order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderLineDelete
+
+Deletes an order line from a draft order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+A related draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderLine</strong></td>
+<td valign="top"><a href="#orderline">OrderLine</a></td>
+<td>
+
+An order line that was deleted.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderLineUpdate
+
+Updates an order line of a draft order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+A related draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderLine</strong></td>
+<td valign="top"><a href="#orderline">OrderLine</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderLinesBulkDelete
+
+Deletes order lines.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderLinesCreate
+
+Create order lines for a draft order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+A related draft order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderLines</strong></td>
+<td valign="top">[<a href="#orderline">OrderLine</a>!]</td>
+<td>
+
+List of newly added order lines.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderUpdate
+
+Updates a draft order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Error
+
+Represents an error in the input of a mutation.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ExtensionsError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#extensionserrorcode">ExtensionsErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Fulfillment
+
+Represents order fulfillment.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>fulfillmentOrder</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top"><a href="#fulfillmentstatus">FulfillmentStatus</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackingNumber</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#fulfillmentline">FulfillmentLine</a>]</td>
+<td>
+
+List of lines for the fulfillment
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>statusDisplay</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+User-friendly fulfillment status.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentCancel
+
+Cancels existing fulfillment
+        and optionally restocks items.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>fulfillment</strong></td>
+<td valign="top"><a href="#fulfillment">Fulfillment</a></td>
+<td>
+
+A canceled fulfillment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Order which fulfillment was cancelled.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentCreate
+
+Creates a new fulfillment for an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>fulfillment</strong></td>
+<td valign="top"><a href="#fulfillment">Fulfillment</a></td>
+<td>
+
+A created fulfillment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Fulfilled order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentLine
+
+Represents line of the fulfillment.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderLine</strong></td>
+<td valign="top"><a href="#orderline">OrderLine</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentUpdateTracking
+
+Updates a fulfillment for an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>fulfillment</strong></td>
+<td valign="top"><a href="#fulfillment">Fulfillment</a></td>
+<td>
+
+A fulfillment with updated tracking.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Order which fulfillment was updated.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Geolocalization
+
+Represents customers's geolocalization data.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>country</strong></td>
+<td valign="top"><a href="#countrydisplay">CountryDisplay</a></td>
+<td>
+
+Country of the user acquired by his IP address.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCard
+
+
+        A gift card is a prepaid electronic payment card accepted in stores.
+        They can be used during checkout by providing a valid gift
+        card codes. 
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Gift card code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+The customer who bought a gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#date">Date</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastUsedOn</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>initialBalance</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>currentBalance</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>displayCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Code in format with allows displaying in a user interface.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardActivate
+
+Activate a gift card.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCard</strong></td>
+<td valign="top"><a href="#giftcard">GiftCard</a></td>
+<td>
+
+A gift card to activate.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardErrors</strong></td>
+<td valign="top">[<a href="#giftcarderror">GiftCardError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#giftcardcountableedge">GiftCardCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#giftcard">GiftCard</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardCreate
+
+Creates a new gift card
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardErrors</strong></td>
+<td valign="top">[<a href="#giftcarderror">GiftCardError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCard</strong></td>
+<td valign="top"><a href="#giftcard">GiftCard</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardDeactivate
+
+Deactivate a gift card.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCard</strong></td>
+<td valign="top"><a href="#giftcard">GiftCard</a></td>
+<td>
+
+A gift card to deactivate.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardErrors</strong></td>
+<td valign="top">[<a href="#giftcarderror">GiftCardError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#giftcarderrorcode">GiftCardErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardUpdate
+
+Update a gift card.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCardErrors</strong></td>
+<td valign="top">[<a href="#giftcarderror">GiftCardError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCard</strong></td>
+<td valign="top"><a href="#giftcard">GiftCard</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### HomepageCollectionUpdate
+
+Updates homepage collection of the shop
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Image
+
+Represents an image.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The URL of the image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>alt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Alt text for an image.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### LanguageDisplay
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+Language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Language.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### LoggedUserUpdate
+
+DEPRECATED: Will be removed in Saleor 2.10, use AccountUpdate instead.Updates data of the logged in user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Margin
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>start</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stop</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Menu
+
+Represents a single menu - an object that is used
+               to help navigate through the store.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>items</strong></td>
+<td valign="top">[<a href="#menuitem">MenuItem</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuBulkDelete
+
+Deletes menus.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#menucountableedge">MenuCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#menu">Menu</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuCreate
+
+Creates a new Menu
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuDelete
+
+Deletes a menu.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#menuerrorcode">MenuErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItem
+
+Represents a single item of the related menu.
+        Can store categories, collection or pages.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sortOrder</strong> ⚠️</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+Will be dropped in 2.10 and is deprecated since 2.9: use the position in list instead and relative calculus to determine shift position.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>parent</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#page">Page</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>level</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>children</strong></td>
+<td valign="top">[<a href="#menuitem">MenuItem</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+URL to the menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#menuitemtranslation">MenuItemTranslation</a></td>
+<td>
+
+Returns translated Menu item fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemBulkDelete
+
+Deletes menu items.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#menuitemcountableedge">MenuItemCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemCreate
+
+Creates a new menu item.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItem</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemDelete
+
+Deletes a menu item.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItem</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemMove
+
+Moves items of menus
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td>
+
+Assigned menu to move within.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemTranslate
+
+Creates/Updates translations for Menu Item.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItem</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemUpdate
+
+Updates a menu item.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuItem</strong></td>
+<td valign="top"><a href="#menuitem">MenuItem</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuUpdate
+
+Updates a menu.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menuErrors</strong></td>
+<td valign="top">[<a href="#menuerror">MenuError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MetaClientStore
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Metadata clients name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>metadata</strong></td>
+<td valign="top">[<a href="#metaitem">MetaItem</a>]!</td>
+<td>
+
+Metadata stored for a client.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaItem
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>key</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Key for stored data.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Stored metadata value.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaStore
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>namespace</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of metadata client group.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>clients</strong></td>
+<td valign="top">[<a href="#metaclientstore">MetaClientStore</a>]!</td>
+<td>
+
+List of clients that stored metadata in a group.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Money
+
+Represents amount of money in specific currency.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>currency</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Currency code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>amount</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td>
+
+Amount of money.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>localized</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Money formatted according to the current locale.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MoneyRange
+
+Represents a range of amounts of money.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>start</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Lower bound of a price range.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stop</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Upper bound of a price range.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Navigation
+
+Represents shop's navigation menus.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>main</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td>
+
+Main navigation bar.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>secondary</strong></td>
+<td valign="top"><a href="#menu">Menu</a></td>
+<td>
+
+Secondary navigation bar.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Order
+
+Represents an order in the shop.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top"><a href="#orderstatus">OrderStatus</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>languageCode</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackingClientId</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#shippingmethod">ShippingMethod</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethodName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingPrice</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Total price of shipping.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCards</strong></td>
+<td valign="top">[<a href="#giftcard">GiftCard</a>]</td>
+<td>
+
+List of userd gift cards
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discount</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translatedDiscountName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>displayGrossPrices</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerNote</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weight">Weight</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>fulfillments</strong></td>
+<td valign="top">[<a href="#fulfillment">Fulfillment</a>]!</td>
+<td>
+
+List of shipments for the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#orderline">OrderLine</a>]!</td>
+<td>
+
+List of order lines.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>actions</strong></td>
+<td valign="top">[<a href="#orderaction">OrderAction</a>]!</td>
+<td>
+
+List of actions that can be performed in
+        the current state of an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableShippingMethods</strong></td>
+<td valign="top">[<a href="#shippingmethod">ShippingMethod</a>]</td>
+<td>
+
+Shipping methods that can be used with this order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>number</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+User-friendly number of an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPaid</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Informs if an order is fully paid.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentStatus</strong></td>
+<td valign="top"><a href="#paymentchargestatusenum">PaymentChargeStatusEnum</a></td>
+<td>
+
+Internal payment status.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentStatusDisplay</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+User-friendly payment status.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payments</strong></td>
+<td valign="top">[<a href="#payment">Payment</a>]</td>
+<td>
+
+List of payments for the order
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>total</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Total amount of the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>subtotal</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The sum of line prices not including shipping.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>statusDisplay</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+User-friendly order status.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>canFinalize</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Informs whether a draft order can be finalized(turned into a regular order).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalAuthorized</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Amount authorized for the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCaptured</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Amount captured by payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>events</strong></td>
+<td valign="top">[<a href="#orderevent">OrderEvent</a>]</td>
+<td>
+
+List of events associated with the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalBalance</strong></td>
+<td valign="top"><a href="#money">Money</a>!</td>
+<td>
+
+The difference between the paid and the order total
+        amount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Email address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isShippingRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Returns True, if order requires shipping.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountAmount</strong> ⚠️</td>
+<td valign="top"><a href="#money">Money</a>!</td>
+<td>
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, use discount instead.
+
+</blockquote>
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderAddNote
+
+Adds note to the order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Order with the note added.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>event</strong></td>
+<td valign="top"><a href="#orderevent">OrderEvent</a></td>
+<td>
+
+Order note created.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderBulkCancel
+
+Cancels orders.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderCancel
+
+Cancel an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Canceled order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderCapture
+
+Capture an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Captured order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#ordercountableedge">OrderCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#order">Order</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#ordererrorcode">OrderErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderEvent
+
+History log of the order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>date</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+Date when event happened at in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#ordereventsenum">OrderEventsEnum</a></td>
+<td>
+
+Order event type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+User who performed the action.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Content of the event.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Email of the customer
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>emailType</strong></td>
+<td valign="top"><a href="#ordereventsemailsenum">OrderEventsEmailsEnum</a></td>
+<td>
+
+Type of an email sent to the customer
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>amount</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td>
+
+Amount of money.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The payment ID from the payment gateway
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentGateway</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The payment gateway of the payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Number of items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>composedId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Composed id of the Fulfillment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderNumber</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+User-friendly number of an order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>oversoldItems</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td>
+
+List of oversold lines names.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#ordereventorderlineobject">OrderEventOrderLineObject</a>]</td>
+<td>
+
+The concerned lines.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>fulfilledItems</strong></td>
+<td valign="top">[<a href="#fulfillmentline">FulfillmentLine</a>]</td>
+<td>
+
+The lines fulfilled.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderEventCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#ordereventcountableedge">OrderEventCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderEventCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#orderevent">OrderEvent</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderEventOrderLineObject
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The variant quantity.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderLine</strong></td>
+<td valign="top"><a href="#orderline">OrderLine</a></td>
+<td>
+
+The order line.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>itemName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The variant name.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderLine
+
+Represents order line of particular order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productSku</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isShippingRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityFulfilled</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxRate</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContentUrl</strong></td>
+<td valign="top"><a href="#digitalcontenturl">DigitalContentUrl</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>thumbnail</strong></td>
+<td valign="top"><a href="#image">Image</a></td>
+<td>
+
+The main thumbnail for the ordered product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">size</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Size of thumbnail
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>unitPrice</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Price of the single item in the order line.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td>
+
+
+            A purchased product variant. Note: this field may be null if the
+            variant has been removed from stock at all.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translatedProductName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Product name in the customer's language
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translatedVariantName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Variant name in the customer's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderMarkAsPaid
+
+Mark order as manually paid.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Order marked as paid.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderRefund
+
+Refund an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+A refunded order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderUpdate
+
+Updates an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderUpdateShipping
+
+Updates a shipping method of the order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+Order with updated shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderVoid
+
+Void an order.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td>
+
+A voided order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orderErrors</strong></td>
+<td valign="top">[<a href="#ordererror">OrderError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Page
+
+A static page that can be manually added by a shop
+               operator through the dashboard.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>title</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contentJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#pagetranslation">PageTranslation</a></td>
+<td>
+
+Returns translated Page fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageBulkDelete
+
+Deletes pages.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageBulkPublish
+
+Publish pages.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#pagecountableedge">PageCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#page">Page</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageCreate
+
+Creates a new page.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#page">Page</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PageDelete
+
+Deletes a page.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#page">Page</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PageInfo
+
+The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>hasNextPage</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+When paginating forwards, are there more items?
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+When paginating backwards, are there more items?
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startCursor</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+When paginating backwards, the cursor to continue.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endCursor</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+When paginating forwards, the cursor to continue.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageTranslate
+
+Creates/Updates translations for Page.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#page">Page</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PageTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>title</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contentJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageUpdate
+
+Updates an existing page.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#page">Page</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PasswordChange
+
+Change the password of the logged in user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+A user instance with a new password.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PasswordReset
+
+DEPRECATED: Will be removed in Saleor 2.10, use RequestPasswordReset instead. Sends an email with the account password change link to customer.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Payment
+
+Represents a payment of a given type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>gateway</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>modified</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>order</strong></td>
+<td valign="top"><a href="#order">Order</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>billingEmail</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customerIpAddress</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>extraData</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>chargeStatus</strong></td>
+<td valign="top"><a href="#paymentchargestatusenum">PaymentChargeStatusEnum</a>!</td>
+<td>
+
+Internal payment status.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>actions</strong></td>
+<td valign="top">[<a href="#orderaction">OrderAction</a>]!</td>
+<td>
+
+List of actions that can be performed in
+        the current state of a payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>total</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Total amount of the payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>capturedAmount</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Total amount captured for this payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td>
+
+Customer billing address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>transactions</strong></td>
+<td valign="top">[<a href="#transaction">Transaction</a>]</td>
+<td>
+
+List of all transactions within this payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableCaptureAmount</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Maximum amount of money that can be captured.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableRefundAmount</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Maximum amount of money that can be refunded.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>creditCard</strong></td>
+<td valign="top"><a href="#creditcard">CreditCard</a></td>
+<td>
+
+The details of the card used for this payment.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PaymentCapture
+
+Captures the authorized payment amount
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a></td>
+<td>
+
+Updated payment
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentErrors</strong></td>
+<td valign="top">[<a href="#paymenterror">PaymentError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PaymentCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#paymentcountableedge">PaymentCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PaymentCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#payment">Payment</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PaymentError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#paymenterrorcode">PaymentErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PaymentRefund
+
+Refunds the captured payment amount
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a></td>
+<td>
+
+Updated payment
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentErrors</strong></td>
+<td valign="top">[<a href="#paymenterror">PaymentError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PaymentSecureConfirm
+
+Confirms payment in two step process like 3D secure
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a></td>
+<td>
+
+Updated payment
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentErrors</strong></td>
+<td valign="top">[<a href="#paymenterror">PaymentError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PaymentSource
+
+Represents a payment source stored for user in payment gateway, such as credit card.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>gateway</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Payment gateway name
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>creditCardInfo</strong></td>
+<td valign="top"><a href="#creditcard">CreditCard</a></td>
+<td>
+
+Stored credit card details if available
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PaymentVoid
+
+Voids the authorized payment
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a></td>
+<td>
+
+Updated payment
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>paymentErrors</strong></td>
+<td valign="top">[<a href="#paymenterror">PaymentError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PermissionDisplay
+
+Represents a permission object in a friendly form.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#permissionenum">PermissionEnum</a>!</td>
+<td>
+
+Internal code for permission.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Describe action(s) allowed to do by permission.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Plugin
+
+Plugin
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>active</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>configuration</strong></td>
+<td valign="top">[<a href="#configurationitem">ConfigurationItem</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PluginCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#plugincountableedge">PluginCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PluginCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#plugin">Plugin</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PluginUpdate
+
+Update plugin configuration
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>plugin</strong></td>
+<td valign="top"><a href="#plugin">Plugin</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>extensionsErrors</strong></td>
+<td valign="top">[<a href="#extensionserror">ExtensionsError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Product
+
+Represents an individual item for sale in the
+        storefront.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#category">Category</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>chargeTaxes</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weight">Weight</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The storefront URL for the product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>thumbnail</strong></td>
+<td valign="top"><a href="#image">Image</a></td>
+<td>
+
+The main thumbnail for a product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">size</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Size of thumbnail
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availability</strong> ⚠️</td>
+<td valign="top"><a href="#productpricinginfo">ProductPricingInfo</a></td>
+<td>
+
+Informs about product's availability in the
+               storefront, current price and discounts.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, Has been renamed to 'pricing'.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pricing</strong></td>
+<td valign="top"><a href="#productpricinginfo">ProductPricingInfo</a></td>
+<td>
+
+Lists the storefront product's pricing,
+            the current price and discounts, only meant for displaying.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isAvailable</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the product is in stock and visible or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>basePrice</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+The product's default base price.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>price</strong> ⚠️</td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+The product's default base price.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'basePrice'
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minimalVariantPrice</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+The price of the cheapest variant (including discounts).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxType</strong></td>
+<td valign="top"><a href="#taxtype">TaxType</a></td>
+<td>
+
+A type of tax. Assigned by enabled tax gateway
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#selectedattribute">SelectedAttribute</a>!]!</td>
+<td>
+
+List of attributes assigned to this product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>purchaseCost</strong></td>
+<td valign="top"><a href="#moneyrange">MoneyRange</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>margin</strong></td>
+<td valign="top"><a href="#margin">Margin</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>imageById</strong></td>
+<td valign="top"><a href="#productimage">ProductImage</a></td>
+<td>
+
+Get a single product image by ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of a product image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variants</strong></td>
+<td valign="top">[<a href="#productvariant">ProductVariant</a>]</td>
+<td>
+
+List of variants for the product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>images</strong></td>
+<td valign="top">[<a href="#productimage">ProductImage</a>]</td>
+<td>
+
+List of images for the product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#collection">Collection</a>]</td>
+<td>
+
+List of collections for the product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#producttranslation">ProductTranslation</a></td>
+<td>
+
+Returns translated Product fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The slug of a product.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductBulkDelete
+
+Deletes products.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductBulkPublish
+
+Publish products.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductClearMeta
+
+Clears public metadata item for product
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductClearPrivateMeta
+
+Clears public metadata item for product
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#productcountableedge">ProductCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#product">Product</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductCreate
+
+Creates a new product.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductDelete
+
+Deletes a product.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#producterrorcode">ProductErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductImage
+
+Represents a product image.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>sortOrder</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>alt</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The URL of the image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">size</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Size of the image
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageBulkDelete
+
+Deletes product images.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageCreate
+
+Create a product image. This mutation must be
+        sent as a `multipart` request. More detailed specs of the upload format
+        can be found here:
+        https://github.com/jaydenseric/graphql-multipart-request-spec
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#productimage">ProductImage</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageDelete
+
+Deletes a product image.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#productimage">ProductImage</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageReorder
+
+Changes ordering of the product image.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>images</strong></td>
+<td valign="top">[<a href="#productimage">ProductImage</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageUpdate
+
+Updates a product image.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#productimage">ProductImage</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductPricingInfo
+
+Represents availability of a product in the storefront.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>available</strong> ⚠️</td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether it is in stock and visible or not.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>onSale</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether it is in sale or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discount</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The discount amount if in sale (null otherwise).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountLocalCurrency</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The discount amount in the local currency.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceRange</strong></td>
+<td valign="top"><a href="#taxedmoneyrange">TaxedMoneyRange</a></td>
+<td>
+
+The discounted price range of the product variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceRangeUndiscounted</strong></td>
+<td valign="top"><a href="#taxedmoneyrange">TaxedMoneyRange</a></td>
+<td>
+
+The undiscounted price range of the product variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceRangeLocalCurrency</strong></td>
+<td valign="top"><a href="#taxedmoneyrange">TaxedMoneyRange</a></td>
+<td>
+
+The discounted price range of the product variants in the local currency.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductTranslate
+
+Creates/Updates translations for Product.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductType
+
+Represents a type of product. It defines what
+        attributes are available to products of this type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>hasVariants</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isShippingRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isDigital</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weight">Weight</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top"><a href="#productcountableconnection">ProductCountableConnection</a></td>
+<td>
+
+List of products of this type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxRate</strong></td>
+<td valign="top"><a href="#taxratetype">TaxRateType</a></td>
+<td>
+
+A type of tax rate.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxType</strong></td>
+<td valign="top"><a href="#taxtype">TaxType</a></td>
+<td>
+
+A type of tax. Assigned by enabled tax gateway
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantAttributes</strong></td>
+<td valign="top">[<a href="#attribute">Attribute</a>]</td>
+<td>
+
+Variant attributes of that product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productAttributes</strong></td>
+<td valign="top">[<a href="#attribute">Attribute</a>]</td>
+<td>
+
+Product attributes of that product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableAttributes</strong></td>
+<td valign="top"><a href="#attributecountableconnection">AttributeCountableConnection</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">filter</td>
+<td valign="top"><a href="#attributefilterinput">AttributeFilterInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeBulkDelete
+
+Deletes product types.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeClearMeta
+
+Clears public metadata item for product type
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeClearPrivateMeta
+
+Clears public metadata item for product type
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#producttypecountableedge">ProductTypeCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeCreate
+
+Creates a new product type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeDelete
+
+Deletes a product type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeReorderAttributes
+
+Reorder the attributes of a product type
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td>
+
+Product type from which attributes are reordered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeUpdate
+
+Updates an existing product type.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeUpdateMeta
+
+Update public metadata for product type
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeUpdatePrivateMeta
+
+Update public metadata for product type
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttype">ProductType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductUpdate
+
+Updates an existing product.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductUpdateMeta
+
+Update public metadata for product
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductUpdatePrivateMeta
+
+Update public metadata for product
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariant
+
+Represents a version of a product such as
+        different size or color.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sku</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#product">Product</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventory</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityAllocated</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weight">Weight</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stockQuantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Quantity of a product available for sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceOverride</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+
+               Override the base price of a product if necessary.
+               A value of `null` indicates that the default product
+               price is used.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>price</strong> ⚠️</td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Price of the product variant.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'pricing.priceUndiscounted'
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availability</strong> ⚠️</td>
+<td valign="top"><a href="#variantpricinginfo">VariantPricingInfo</a></td>
+<td>
+
+Informs about variant's availability in the
+               storefront, current price and discounted price.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, has been renamed to 'pricing'.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pricing</strong></td>
+<td valign="top"><a href="#variantpricinginfo">VariantPricingInfo</a></td>
+<td>
+
+Lists the storefront variant's pricing,
+            the current price and discounts, only meant for displaying
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isAvailable</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the variant is in stock and visible or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#selectedattribute">SelectedAttribute</a>!]!</td>
+<td>
+
+List of attributes assigned to this variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>costPrice</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Cost price of the variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>margin</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Gross margin percentage value.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityOrdered</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Total quantity ordered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>revenue</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Total revenue generated by a variant in given
+        period of time. Note: this field should be queried using
+        `reportProductSales` query as it uses optimizations suitable
+        for such calculations.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">period</td>
+<td valign="top"><a href="#reportingperiod">ReportingPeriod</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>images</strong></td>
+<td valign="top">[<a href="#productimage">ProductImage</a>]</td>
+<td>
+
+List of images for the product variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#productvarianttranslation">ProductVariantTranslation</a></td>
+<td>
+
+Returns translated Product Variant fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>digitalContent</strong></td>
+<td valign="top"><a href="#digitalcontent">DigitalContent</a></td>
+<td>
+
+Digital content for the product variant
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantBulkDelete
+
+Deletes product variants.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantClearMeta
+
+Clears public metadata item for product variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantClearPrivateMeta
+
+Clears public metadata item for product variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#productvariantcountableedge">ProductVariantCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantCreate
+
+Creates a new variant for a product
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantDelete
+
+Deletes a product variant.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantTranslate
+
+Creates/Updates translations for Product Variant.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantUpdate
+
+Updates an existing variant for product
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantUpdateMeta
+
+Update public metadata for product variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantUpdatePrivateMeta
+
+Update public metadata for product variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ReducedRate
+
+Represents a reduced VAT rate for a particular type of goods.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>rate</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td>
+
+Reduced VAT rate in percent.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>rateType</strong></td>
+<td valign="top"><a href="#taxratetype">TaxRateType</a>!</td>
+<td>
+
+A type of goods.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Refresh
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payload</strong></td>
+<td valign="top"><a href="#genericscalar">GenericScalar</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### RequestPasswordReset
+
+Sends an email with the account password modification link.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Sale
+
+
+        Sales allow creating discounts for categories, collections or
+        products and are visible to all the customers.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#saletype">SaleType</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top"><a href="#categorycountableconnection">CategoryCountableConnection</a></td>
+<td>
+
+List of categories this sale applies to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top"><a href="#collectioncountableconnection">CollectionCountableConnection</a></td>
+<td>
+
+List of collections this sale applies to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top"><a href="#productcountableconnection">ProductCountableConnection</a></td>
+<td>
+
+List of products this sale applies to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#saletranslation">SaleTranslation</a></td>
+<td>
+
+Returns translated sale fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleAddCatalogues
+
+Adds products, categories, collections to a voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td>
+
+Sale of which catalogue IDs will be modified.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleBulkDelete
+
+Deletes sales.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#salecountableedge">SaleCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#sale">Sale</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleCreate
+
+Creates a new sale.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SaleDelete
+
+Deletes a sale.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SaleRemoveCatalogues
+
+Removes products, categories, collections from a sale.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td>
+
+Sale of which catalogue IDs will be modified.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleTranslate
+
+Creates/updates translations for a sale.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SaleTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleUpdate
+
+Updates a sale.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sale</strong></td>
+<td valign="top"><a href="#sale">Sale</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SelectedAttribute
+
+Represents a custom attribute.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>attribute</strong></td>
+<td valign="top"><a href="#attribute">Attribute</a>!</td>
+<td>
+
+Name of an attribute displayed in the interface.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong> ⚠️</td>
+<td valign="top"><a href="#attributevalue">AttributeValue</a></td>
+<td>
+
+The value or the first value of an attribute.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, use values instead.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>values</strong></td>
+<td valign="top">[<a href="#attributevalue">AttributeValue</a>]!</td>
+<td>
+
+Values of an attribute.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccount
+
+Represents service account data.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>authToken</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Last 4 characters of the token
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+The date and time when the service account was created.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determine if service account will be set active or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>permissions</strong></td>
+<td valign="top">[<a href="#permissiondisplay">PermissionDisplay</a>]</td>
+<td>
+
+List of the service's permissions.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the service account.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountClearStoredPrivateMeta
+
+Clear stored metadata value.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccount</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#serviceaccountcountableedge">ServiceAccountCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountCreate
+
+Creates a new service account
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>authToken</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The newly created authentication token
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccount</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountDelete
+
+Deletes a service account
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccount</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountUpdate
+
+Updates an existing service account
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccount</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountUpdatePrivateMeta
+
+Updates private metadata for a service account.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>serviceAccount</strong></td>
+<td valign="top"><a href="#serviceaccount">ServiceAccount</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SetPassword
+
+Sets the user's password from the token sent by email using the RequestPasswordReset mutation.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+An user instance with new password.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#shippingerrorcode">ShippingErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingMethod
+
+
+            Shipping method are the methods you'll use to get
+            customer's orders to them.
+            They are directly exposed to the customers.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>price</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minimumOrderPrice</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maximumOrderPrice</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minimumOrderWeight</strong></td>
+<td valign="top"><a href="#weight">Weight</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maximumOrderWeight</strong></td>
+<td valign="top"><a href="#weight">Weight</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#shippingmethodtypeenum">ShippingMethodTypeEnum</a></td>
+<td>
+
+Type of the shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#shippingmethodtranslation">ShippingMethodTranslation</a></td>
+<td>
+
+Returns translated Shipping Method fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingMethodTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingPriceBulkDelete
+
+Deletes shipping prices.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingPriceCreate
+
+Creates a new shipping price.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td>
+
+A shipping zone to which the shipping method belongs.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#shippingmethod">ShippingMethod</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingPriceDelete
+
+Deletes a shipping price.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#shippingmethod">ShippingMethod</a></td>
+<td>
+
+A shipping method to delete.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td>
+
+A shipping zone to which the shipping method belongs.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingPriceTranslate
+
+Creates/Updates translations for Shipping Method.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#shippingmethod">ShippingMethod</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingPriceUpdate
+
+Updates a new shipping price.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td>
+
+A shipping zone to which the shipping method belongs.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#shippingmethod">ShippingMethod</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZone
+
+
+            Represents a shipping zone in the shop. Zones are the concept
+            used only for grouping shipping methods in the dashboard,
+            and are never exposed to the customers directly.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>default</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceRange</strong></td>
+<td valign="top"><a href="#moneyrange">MoneyRange</a></td>
+<td>
+
+Lowest and highest prices for the shipping.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countries</strong></td>
+<td valign="top">[<a href="#countrydisplay">CountryDisplay</a>]</td>
+<td>
+
+List of countries available for the method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethods</strong></td>
+<td valign="top">[<a href="#shippingmethod">ShippingMethod</a>]</td>
+<td>
+
+List of shipping methods available for orders shipped to countries within this shipping zone.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneBulkDelete
+
+Deletes shipping zones.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#shippingzonecountableedge">ShippingZoneCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneCreate
+
+Creates a new shipping zone.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneDelete
+
+Deletes a shipping zone.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneUpdate
+
+Updates a new shipping zone.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#shippingzone">ShippingZone</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingErrors</strong></td>
+<td valign="top">[<a href="#shippingerror">ShippingError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Shop
+
+
+        Represents a shop resource containing general shop's data
+        and configuration.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>geolocalization</strong></td>
+<td valign="top"><a href="#geolocalization">Geolocalization</a></td>
+<td>
+
+Customer's geolocalization data.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>authorizationKeys</strong></td>
+<td valign="top">[<a href="#authorizationkey">AuthorizationKey</a>]!</td>
+<td>
+
+List of configured authorization keys. Authorization
+               keys are used to enable third party OAuth authorization
+               (currently Facebook or Google).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countries</strong></td>
+<td valign="top">[<a href="#countrydisplay">CountryDisplay</a>]!</td>
+<td>
+
+List of countries available in the shop.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a></td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>currencies</strong></td>
+<td valign="top">[<a href="#string">String</a>]!</td>
+<td>
+
+List of available currencies.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultCurrency</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Default shop's currency.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultCountry</strong></td>
+<td valign="top"><a href="#countrydisplay">CountryDisplay</a></td>
+<td>
+
+Default shop's country
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Shop's description.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>domain</strong></td>
+<td valign="top"><a href="#domain">Domain</a>!</td>
+<td>
+
+Shop's domain data.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>homepageCollection</strong></td>
+<td valign="top"><a href="#collection">Collection</a></td>
+<td>
+
+Collection displayed on homepage
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>languages</strong></td>
+<td valign="top">[<a href="#languagedisplay">LanguageDisplay</a>]!</td>
+<td>
+
+List of the shops's supported languages.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Shop's name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>navigation</strong></td>
+<td valign="top"><a href="#navigation">Navigation</a></td>
+<td>
+
+Shop's navigation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>permissions</strong></td>
+<td valign="top">[<a href="#permissiondisplay">PermissionDisplay</a>]!</td>
+<td>
+
+List of available permissions.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phonePrefixes</strong></td>
+<td valign="top">[<a href="#string">String</a>]!</td>
+<td>
+
+List of possible phone prefixes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>headerText</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Header text
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>includeTaxesInPrices</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Include taxes in prices
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>displayGrossPrices</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Display prices with tax in store
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>chargeTaxesOnShipping</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Charge taxes on shipping
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventoryByDefault</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Enable inventory tracking
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultWeightUnit</strong></td>
+<td valign="top"><a href="#weightunitsenum">WeightUnitsEnum</a></td>
+<td>
+
+Default weight unit
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#shoptranslation">ShopTranslation</a></td>
+<td>
+
+Returns translated Shop fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>automaticFulfillmentDigitalProducts</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Enable automatic fulfillment for all digital products
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultDigitalMaxDownloads</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Default number of max downloads per digital content url
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultDigitalUrlValidDays</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Default number of days which digital content url will be valid
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td>
+
+Company address
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShopAddressUpdate
+
+Update shop address
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShopDomainUpdate
+
+Updates site domain of the shop
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShopError
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The error message.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#shoperrorcode">ShopErrorCode</a></td>
+<td>
+
+The error code.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShopFetchTaxRates
+
+Fetch tax rates
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShopSettingsTranslate
+
+Creates/Updates translations for Shop Settings.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShopSettingsUpdate
+
+Updates shop settings
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shop</strong></td>
+<td valign="top"><a href="#shop">Shop</a></td>
+<td>
+
+Updated Shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shopErrors</strong></td>
+<td valign="top">[<a href="#shoperror">ShopError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShopTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>headerText</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### StaffBulkDelete
+
+Deletes staff users.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StaffCreate
+
+Creates a new staff user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StaffDelete
+
+Deletes a staff user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StaffUpdate
+
+Updates an existing staff user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TaxType
+
+Representation of tax types fetched from tax gateway.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Description of the tax type
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+External tax code used to identify given tax group
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### TaxedMoney
+
+Represents a monetary value with taxes. In
+        case when taxes were not applied, net and gross values will be equal.
+        
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>currency</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Currency code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>gross</strong></td>
+<td valign="top"><a href="#money">Money</a>!</td>
+<td>
+
+Amount of money including taxes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>net</strong></td>
+<td valign="top"><a href="#money">Money</a>!</td>
+<td>
+
+Amount of money without taxes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>tax</strong></td>
+<td valign="top"><a href="#money">Money</a>!</td>
+<td>
+
+Amount of taxes.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### TaxedMoneyRange
+
+Represents a range of monetary values.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>start</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Lower bound of a price range.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stop</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+Upper bound of a price range.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### Transaction
+
+An object representing a single payment.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>payment</strong></td>
+<td valign="top"><a href="#payment">Payment</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>kind</strong></td>
+<td valign="top"><a href="#transactionkind">TransactionKind</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isSuccess</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>error</strong></td>
+<td valign="top"><a href="#transactionerror">TransactionError</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>gatewayResponse</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>amount</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+
+Total amount of the transaction.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### TranslatableItemConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#translatableitemedge">TranslatableItemEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### TranslatableItemEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#translatableitem">TranslatableItem</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### User
+
+Represents user data.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastLogin</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isStaff</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>note</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+A note about the customer
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>dateJoined</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultShippingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultBillingAddress</strong></td>
+<td valign="top"><a href="#address">Address</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>privateMeta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of privately stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>meta</strong></td>
+<td valign="top">[<a href="#metastore">MetaStore</a>]!</td>
+<td>
+
+List of publicly stored metadata namespaces.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addresses</strong></td>
+<td valign="top">[<a href="#address">Address</a>]</td>
+<td>
+
+List of all user's addresses.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>checkout</strong></td>
+<td valign="top"><a href="#checkout">Checkout</a></td>
+<td>
+
+Returns the last open checkout of this user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>giftCards</strong></td>
+<td valign="top"><a href="#giftcardcountableconnection">GiftCardCountableConnection</a></td>
+<td>
+
+List of the user gift cards.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>orders</strong></td>
+<td valign="top"><a href="#ordercountableconnection">OrderCountableConnection</a></td>
+<td>
+
+List of user's orders.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>permissions</strong></td>
+<td valign="top">[<a href="#permissiondisplay">PermissionDisplay</a>]</td>
+<td>
+
+List of user's permissions.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>avatar</strong></td>
+<td valign="top"><a href="#image">Image</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">size</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Size of the avatar.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>events</strong></td>
+<td valign="top">[<a href="#customerevent">CustomerEvent</a>]</td>
+<td>
+
+List of events associated with the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>storedPaymentSources</strong></td>
+<td valign="top">[<a href="#paymentsource">PaymentSource</a>]</td>
+<td>
+
+List of stored payment sources
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### UserAvatarDelete
+
+Deletes a user avatar. Only for staff members.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+An updated user instance.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserAvatarUpdate
+
+
+            Create a user avatar. Only for staff members. This mutation must
+            be sent as a `multipart` request. More detailed specs of the
+            upload format can be found here:
+            https://github.com/jaydenseric/graphql-multipart-request-spec
+            
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+An updated user instance.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserBulkSetActive
+
+Activate or deactivate users.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserClearStoredMeta
+
+Clear stored metadata value.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserClearStoredPrivateMeta
+
+Clear stored metadata value.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#usercountableedge">UserCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### UserCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#user">User</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### UserUpdateMeta
+
+Updates metadata for user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserUpdatePrivateMeta
+
+Updates private metadata for user.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>accountErrors</strong></td>
+<td valign="top">[<a href="#accounterror">AccountError</a>!]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VAT
+
+Represents a VAT rate for a country.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>countryCode</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Country code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>standardRate</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td>
+
+Standard VAT rate in percent.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>reducedRates</strong></td>
+<td valign="top">[<a href="#reducedrate">ReducedRate</a>]!</td>
+<td>
+
+Country's VAT rate exceptions for specific types of goods.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VariantImageAssign
+
+Assign an image to a product variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#productimage">ProductImage</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VariantImageUnassign
+
+Unassign an image from a product variant
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productVariant</strong></td>
+<td valign="top"><a href="#productvariant">ProductVariant</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#productimage">ProductImage</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productErrors</strong></td>
+<td valign="top">[<a href="#producterror">ProductError</a>!]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VariantPricingInfo
+
+Represents availability of a variant in the storefront.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>available</strong> ⚠️</td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether it is in stock and visible or not.
+
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.
+
+</blockquote>
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>onSale</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether it is in sale or not.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discount</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The discount amount if in sale (null otherwise).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountLocalCurrency</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The discount amount in the local currency.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>price</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The price, with any discount subtracted.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceUndiscounted</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The price without any discount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceLocalCurrency</strong></td>
+<td valign="top"><a href="#taxedmoney">TaxedMoney</a></td>
+<td>
+
+The discounted price in the local currency.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VerifyToken
+
+Mutation that confirm if token is valid and also return user data.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>payload</strong></td>
+<td valign="top"><a href="#genericscalar">GenericScalar</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Voucher
+
+
+        Vouchers allow giving discounts to particular customers on categories,
+        collections or specific products. They can be used during checkout by
+        providing valid voucher codes.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#vouchertypeenum">VoucherTypeEnum</a>!</td>
+<td>
+
+Determines a type of voucher
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>usageLimit</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>used</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>applyOncePerOrder</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>applyOncePerCustomer</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountValueType</strong></td>
+<td valign="top"><a href="#discountvaluetypeenum">DiscountValueTypeEnum</a>!</td>
+<td>
+
+Determines a type of discount for voucher - value or percentage
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountValue</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minSpent</strong></td>
+<td valign="top"><a href="#money">Money</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minCheckoutItemsQuantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top"><a href="#categorycountableconnection">CategoryCountableConnection</a></td>
+<td>
+
+List of categories this voucher applies to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top"><a href="#collectioncountableconnection">CollectionCountableConnection</a></td>
+<td>
+
+List of collections this voucher applies to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top"><a href="#productcountableconnection">ProductCountableConnection</a></td>
+<td>
+
+List of products this voucher applies to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">before</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come before the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">after</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Returns the elements in the list that come after the specified cursor.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">first</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the first n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">last</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Returns the last n elements from the list.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countries</strong></td>
+<td valign="top">[<a href="#countrydisplay">CountryDisplay</a>]</td>
+<td>
+
+List of countries available for the shipping voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>translation</strong></td>
+<td valign="top"><a href="#vouchertranslation">VoucherTranslation</a></td>
+<td>
+
+Returns translated Voucher fields for the given language code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">languageCode</td>
+<td valign="top"><a href="#languagecodeenum">LanguageCodeEnum</a>!</td>
+<td>
+
+A language code to return the translation for.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minAmountSpent</strong> ⚠️</td>
+<td valign="top"><a href="#money">Money</a></td>
+<td>
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+DEPRECATED: Will be removed in Saleor 2.10, use the minSpent field instead.
+
+</blockquote>
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherAddCatalogues
+
+Adds products, categories, collections to a voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td>
+
+Voucher of which catalogue IDs will be modified.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherBulkDelete
+
+Deletes vouchers.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Returns how many objects were affected.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherCountableConnection
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td>
+
+Pagination data for this connection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#vouchercountableedge">VoucherCountableEdge</a>!]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>totalCount</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+A total count of items in the collection
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherCountableEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a>!</td>
+<td>
+
+The item at the end of the edge
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+A cursor for use in pagination
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherCreate
+
+Creates a new voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VoucherDelete
+
+Deletes a voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VoucherRemoveCatalogues
+
+Removes products, categories, collections from a voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td>
+
+Voucher of which catalogue IDs will be modified.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherTranslate
+
+Creates/Updates translations for Voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VoucherTranslation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>language</strong></td>
+<td valign="top"><a href="#languagedisplay">LanguageDisplay</a>!</td>
+<td>
+
+Translation's language
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherUpdate
+
+Updates a voucher.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>errors</strong></td>
+<td valign="top">[<a href="#error">Error</a>!]</td>
+<td>
+
+List of errors that occurred executing the mutation.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#voucher">Voucher</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Weight
+
+Represents weight value in a specific weight unit.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>unit</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Weight unit
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td>
+
+Weight value
+
+</td>
+</tr>
+</tbody>
+</table>
+
+## Inputs
+
+### AccountInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Family name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultBillingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultShippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AccountRegisterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The email address of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>password</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Password
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AddressInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Family name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Company or organization.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>streetAddress1</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>streetAddress2</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>city</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+City.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cityArea</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+District.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>postalCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Postal code.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>country</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Country.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countryArea</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+State or province.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Phone number.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeAssignInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the attribute to assign
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#attributetypeenum">AttributeTypeEnum</a>!</td>
+<td>
+
+The attribute type to be assigned as.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>inputType</strong></td>
+<td valign="top"><a href="#attributeinputtypeenum">AttributeInputTypeEnum</a></td>
+<td>
+
+The input type to use for entering attribute values in the dashboard.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of an attribute displayed in the interface.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Internal representation of an attribute name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>values</strong></td>
+<td valign="top">[<a href="#attributevaluecreateinput">AttributeValueCreateInput</a>]</td>
+<td>
+
+List of attribute's values.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>valueRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute requires values to be passed or not
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isVariantOnly</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute is for variants only
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>visibleInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute should be visible or not in storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute can be filtered in storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInDashboard</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute can be filtered in dashboard
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>storefrontSearchPosition</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The position of the attribute in the storefront navigation (0 by default)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableInGrid</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute can be displayed in the admin product list
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>valueRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isVariantOnly</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>visibleInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInDashboard</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableInGrid</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>ids</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Internal representation of an attribute name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Internal representation of a value (unique per attribute).
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeSortingInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#attributesortfield">AttributeSortField</a>!</td>
+<td>
+
+Sort attributes by the selected field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>direction</strong></td>
+<td valign="top"><a href="#orderdirection">OrderDirection</a>!</td>
+<td>
+
+Specifies the direction in which to sort the attributes
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeUpdateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of an attribute displayed in the interface.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Internal representation of an attribute name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>removeValues</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+IDs of values to be removed from this attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>addValues</strong></td>
+<td valign="top">[<a href="#attributevaluecreateinput">AttributeValueCreateInput</a>]</td>
+<td>
+
+New values to be created for this attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>valueRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute requires values to be passed or not
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isVariantOnly</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute is for variants only
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>visibleInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute should be visible or not in storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInStorefront</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute can be filtered in storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>filterableInDashboard</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute can be filtered in dashboard
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>storefrontSearchPosition</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The position of the attribute in the storefront navigation (0 by default)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>availableInGrid</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether the attribute can be displayed in the admin product list
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of a value displayed in the interface.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the selected attribute
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Slug of the selected attribute.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>values</strong></td>
+<td valign="top">[<a href="#string">String</a>]!</td>
+<td>
+
+The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AuthorizationKeyInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>key</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Client authorization key (client ID).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>password</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Client secret.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CatalogueInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Products related to the discount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Categories related to the discount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Collections related to the discount.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CategoryFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CategoryInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Category description (HTML/text).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td>
+
+Category description (JSON).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Category name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Category slug.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seo</strong></td>
+<td valign="top"><a href="#seoinput">SeoInput</a></td>
+<td>
+
+Search engine optimization fields.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImage</strong></td>
+<td valign="top"><a href="#upload">Upload</a></td>
+<td>
+
+Background image file.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImageAlt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Alt text for an image.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#checkoutlineinput">CheckoutLineInput</a>]!</td>
+<td>
+
+A list of checkout lines, each containing information about an item in the checkout.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The customer's email address.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+The mailing address to where the checkout will be shipped. Note: the address will be ignored if the checkout doesn't contain shippable items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutLineInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+The number of items purchased.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantId</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the ProductVariant.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CollectionCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Informs whether a collection is published.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Slug of the collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Description of the collection (HTML/text).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td>
+
+Description of the collection (JSON).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImage</strong></td>
+<td valign="top"><a href="#upload">Upload</a></td>
+<td>
+
+Background image file.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImageAlt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Alt text for an image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seo</strong></td>
+<td valign="top"><a href="#seoinput">SeoInput</a></td>
+<td>
+
+Search engine optimization fields.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Publication date. ISO 8601 standard.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+List of products to be added to the collection.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CollectionFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>published</strong></td>
+<td valign="top"><a href="#collectionpublished">CollectionPublished</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Informs whether a collection is published.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Slug of the collection.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Description of the collection (HTML/text).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td>
+
+Description of the collection (JSON).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImage</strong></td>
+<td valign="top"><a href="#upload">Upload</a></td>
+<td>
+
+Background image file.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>backgroundImageAlt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Alt text for an image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seo</strong></td>
+<td valign="top"><a href="#seoinput">SeoInput</a></td>
+<td>
+
+Search engine optimization fields.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Publication date. ISO 8601 standard.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ConfigurationItemInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of the field to update
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Value of the given field to update
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>dateJoined</strong></td>
+<td valign="top"><a href="#daterangeinput">DateRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>moneySpent</strong></td>
+<td valign="top"><a href="#pricerangeinput">PriceRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>numberOfOrders</strong></td>
+<td valign="top"><a href="#intrangeinput">IntRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>placedOrders</strong></td>
+<td valign="top"><a href="#daterangeinput">DateRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>defaultBillingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultShippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Family name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The unique email address of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+User account is active.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>note</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+A note about the user.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerPasswordResetInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Email of the user that will be used for password recovery.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CustomerRegisterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+The unique email address of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>password</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Password
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DateRangeInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>gte</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Start date
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lte</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+End date
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DateTimeRangeInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>gte</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+Start date
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lte</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+End date
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>useDefaultSettings</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Use default digital content settings for this product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maxDownloads</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Determines how many times a download link can be accessed by a customer
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>urlValidDays</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Determines for how many days a download link is active since it was generated.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>automaticFulfillment</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Overwrite default automatic_fulfillment setting for variant
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentUploadInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>useDefaultSettings</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+Use default digital content settings for this product
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maxDownloads</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Determines how many times a download link can be accessed by a customer
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>urlValidDays</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Determines for how many days a download link is active since it was generated.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>automaticFulfillment</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Overwrite default automatic_fulfillment setting for variant
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contentFile</strong></td>
+<td valign="top"><a href="#upload">Upload</a>!</td>
+<td>
+
+Represents an file in a multipart request.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DigitalContentUrlCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Digital content ID which url will belong to
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Email address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discount</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Discount amount for the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of a selected shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the voucher associated with the order
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#orderlinecreateinput">OrderLineCreateInput</a>]</td>
+<td>
+
+Variant line input consisting of variant ID
+        and quantity of products.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### DraftOrderInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Email address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discount</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Discount amount for the order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of a selected shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>voucher</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the voucher associated with the order
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentCancelInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>restock</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether item lines are restocked.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>trackingNumber</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Fulfillment tracking number
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>notifyCustomer</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+If true, send an email notification to the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lines</strong></td>
+<td valign="top">[<a href="#fulfillmentlineinput">FulfillmentLineInput</a>]!</td>
+<td>
+
+Item line to be fulfilled.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentLineInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>orderLineId</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+The ID of the order line.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The number of line item(s) to be fulfilled.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentUpdateTrackingInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>trackingNumber</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Fulfillment tracking number
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>notifyCustomer</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+If true, send an email notification to the customer.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Start date of the gift card in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+End date of the gift card in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>balance</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Value of the gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The customer's email of the gift card buyer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Code to use the gift card.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardUpdateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Start date of the gift card in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+End date of the gift card in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>balance</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Value of the gift card.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The customer's email of the gift card buyer.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### IntRangeInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>gte</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Value greater than or equal
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lte</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Value less than or equal
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of the menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>items</strong></td>
+<td valign="top">[<a href="#menuiteminput">MenuItemInput</a>]</td>
+<td>
+
+List of menu items.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the menu.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of the menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+URL of the pointed item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Category to which item points.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Collection to which item points.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Page to which item points.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>menu</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Menu to which item belongs to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>parent</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+
+        ID of the parent menu. If empty, menu will be top level
+        menu.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the menu item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>url</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+URL of the pointed item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Category to which item points.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collection</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Collection to which item points.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>page</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Page to which item points.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MenuItemMoveInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>itemId</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The menu item ID to move.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>parentId</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the parent menu. If empty, menu will be top level menu.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sortOrder</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Sorting position of the menu item (from 0 to x).
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>namespace</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of metadata client group.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>clientName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Metadata clients name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>key</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Key for stored data.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Stored metadata value.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MetaPath
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>namespace</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Name of metadata client group.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>clientName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Metadata clients name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>key</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Key for stored data.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MoveProductInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>productId</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the product to move.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sortOrder</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The relative sorting position of the product (from -inf to +inf) starting from the first given product's actual position.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### NameTranslationInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderAddNoteInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>message</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Note message.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderDraftFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>customer</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#daterangeinput">DateRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>paymentStatus</strong></td>
+<td valign="top">[<a href="#paymentchargestatusenum">PaymentChargeStatusEnum</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top">[<a href="#orderstatusfilter">OrderStatusFilter</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customer</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>created</strong></td>
+<td valign="top"><a href="#daterangeinput">DateRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderLineCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Number of variant items ordered.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantId</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Product variant ID.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderLineInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td>
+
+Number of variant items ordered.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderUpdateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Email address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderUpdateShippingInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>shippingMethod</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the selected shipping method.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PageInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>slug</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Page internal name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>title</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Page title.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Page content. May consists of ordinary text, HTML and images.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contentJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td>
+
+Page content in JSON format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if page is visible in the storefront
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Publication date. ISO 8601 standard.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seo</strong></td>
+<td valign="top"><a href="#seoinput">SeoInput</a></td>
+<td>
+
+Search engine optimization fields.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PageTranslationInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>title</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>content</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contentJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PaymentInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>gateway</strong></td>
+<td valign="top"><a href="#gatewaysenum">GatewaysEnum</a>!</td>
+<td>
+
+A gateway to use with that payment.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Client-side generated payment token, representing customer's billing data in a secure manner.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>amount</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Total amount of the transaction, including all taxes and discounts. If no amount is provided, the checkout total will be used.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>billingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address. If empty, the billing address associated with
+            the checkout instance will be used.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PluginFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>active</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PluginUpdateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>active</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Indicates whether the plugin should be enabled
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>configuration</strong></td>
+<td valign="top">[<a href="#configurationiteminput">ConfigurationItemInput</a>]</td>
+<td>
+
+Configuration of the plugin
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### PriceRangeInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>gte</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td>
+
+Price greater than or equal
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lte</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td>
+
+Price less than or equal
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#attributevalueinput">AttributeValueInput</a>]</td>
+<td>
+
+List of attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Publication date. ISO 8601 standard.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the product's category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>chargeTaxes</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determine if taxes are being charged for the product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+List of IDs of collections that the product belongs to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Product description (HTML/text).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td>
+
+Product description (JSON).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if product is visible to customers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Product name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>basePrice</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Product price.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Tax rate for enabled tax gateway
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seo</strong></td>
+<td valign="top"><a href="#seoinput">SeoInput</a></td>
+<td>
+
+Search engine optimization fields.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Weight of the Product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sku</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Stock keeping unit of a product. Note: this
+        field is only used if a product doesn't use variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The total quantity of a product available for
+        sale. Note: this field is only used if a product doesn't
+        use variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventory</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if the inventory of this product
+        should be tracked. If false, the quantity won't change when customers
+        buy this item. Note: this field is only used if a product doesn't
+        use variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of the type that product belongs to.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>price</strong></td>
+<td valign="top"><a href="#pricerangeinput">PriceRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#attributeinput">AttributeInput</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stockAvailability</strong></td>
+<td valign="top"><a href="#stockavailability">StockAvailability</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minimalPrice</strong></td>
+<td valign="top"><a href="#pricerangeinput">PriceRangeInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>alt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Alt text for an image.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#upload">Upload</a>!</td>
+<td>
+
+Represents an image file in a multipart request.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID of an product.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductImageUpdateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>alt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Alt text for an image.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#attributevalueinput">AttributeValueInput</a>]</td>
+<td>
+
+List of attributes.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>publicationDate</strong></td>
+<td valign="top"><a href="#date">Date</a></td>
+<td>
+
+Publication date. ISO 8601 standard.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+ID of the product's category.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>chargeTaxes</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determine if taxes are being charged for the product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+List of IDs of collections that the product belongs to.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Product description (HTML/text).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td>
+
+Product description (JSON).
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPublished</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if product is visible to customers.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Product name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>basePrice</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Product price.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Tax rate for enabled tax gateway
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seo</strong></td>
+<td valign="top"><a href="#seoinput">SeoInput</a></td>
+<td>
+
+Search engine optimization fields.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Weight of the Product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sku</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Stock keeping unit of a product. Note: this
+        field is only used if a product doesn't use variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The total quantity of a product available for
+        sale. Note: this field is only used if a product doesn't
+        use variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventory</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if the inventory of this product
+        should be tracked. If false, the quantity won't change when customers
+        buy this item. Note: this field is only used if a product doesn't
+        use variants.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductOrder
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>field</strong></td>
+<td valign="top"><a href="#productorderfield">ProductOrderField</a>!</td>
+<td>
+
+Sort products by the selected field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>direction</strong></td>
+<td valign="top"><a href="#orderdirection">OrderDirection</a>!</td>
+<td>
+
+Specifies the direction in which to sort products
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>configurable</strong></td>
+<td valign="top"><a href="#producttypeconfigurable">ProductTypeConfigurable</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productType</strong></td>
+<td valign="top"><a href="#producttypeenum">ProductTypeEnum</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the product type.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>hasVariants</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if product of this type has multiple
+        variants. This option mainly simplifies product management
+        in the dashboard. There is always at least one variant created under
+        the hood.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>productAttributes</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+List of attributes shared among all product variants.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>variantAttributes</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+List of attributes used to distinguish between
+        different variants of a product.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isShippingRequired</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if shipping is required for products
+        of this variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isDigital</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if products are digital.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Weight of the ProductType items.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>taxCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Tax rate for enabled tax gateway
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#attributevalueinput">AttributeValueInput</a>]!</td>
+<td>
+
+List of attributes specific to this variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>costPrice</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Cost price of the variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceOverride</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Special price of the particular variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sku</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Stock keeping unit.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The total quantity of this variant available for sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventory</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if the inventory of this variant should
+               be tracked. If false, the quantity won't change when customers
+               buy this item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Weight of the Product Variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>product</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+Product ID of which type is the variant.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductVariantInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>attributes</strong></td>
+<td valign="top">[<a href="#attributevalueinput">AttributeValueInput</a>]</td>
+<td>
+
+List of attributes specific to this variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>costPrice</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Cost price of the variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>priceOverride</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Special price of the particular variant.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sku</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Stock keeping unit.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The total quantity of this variant available for sale.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventory</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determines if the inventory of this variant should
+               be tracked. If false, the quantity won't change when customers
+               buy this item.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>weight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Weight of the Product Variant.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ReorderInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the item to move
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sortOrder</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+The new relative sorting position of the item (from -inf to +inf)
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SaleFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top">[<a href="#discountstatusenum">DiscountStatusEnum</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saleType</strong></td>
+<td valign="top"><a href="#discountvaluetypeenum">DiscountValueTypeEnum</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>started</strong></td>
+<td valign="top"><a href="#datetimerangeinput">DateTimeRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SaleInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Voucher name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#discountvaluetypeenum">DiscountValueTypeEnum</a></td>
+<td>
+
+Fixed or percentage.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>value</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Value of the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Products related to the discount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Categories related to the discount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Collections related to the discount.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+Start date of the voucher in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+End date of the voucher in ISO 8601 format.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### SeoInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>title</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+SEO title.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+SEO description.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ServiceAccountInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the service account
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Determine if this service account should be enabled
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>permissions</strong></td>
+<td valign="top">[<a href="#permissionenum">PermissionEnum</a>]</td>
+<td>
+
+List of permission code names to assign to this service account.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingPriceInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Name of the shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>price</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Shipping price of the shipping method.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minimumOrderPrice</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Minimum order price to use this shipping method
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maximumOrderPrice</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Maximum order price to use this shipping method
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minimumOrderWeight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Minimum order weight to use this shipping method
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>maximumOrderWeight</strong></td>
+<td valign="top"><a href="#weightscalar">WeightScalar</a></td>
+<td>
+
+Maximum order weight to use this shipping method
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#shippingmethodtypeenum">ShippingMethodTypeEnum</a></td>
+<td>
+
+Shipping type: price or weight based.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>shippingZone</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Shipping zone this method belongs to.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingZoneInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Shipping zone's name. Visible only to the staff.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countries</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td>
+
+List of countries in this shipping zone.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>default</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+
+            Is default shipping zone, that will be used
+            for countries not covered by other zones.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShopSettingsInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>headerText</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Header text
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+SEO description
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>includeTaxesInPrices</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Include taxes in prices
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>displayGrossPrices</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Display prices with tax in store
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>chargeTaxesOnShipping</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Charge taxes on shipping
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trackInventoryByDefault</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Enable inventory tracking
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultWeightUnit</strong></td>
+<td valign="top"><a href="#weightunitsenum">WeightUnitsEnum</a></td>
+<td>
+
+Default weight unit
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>automaticFulfillmentDigitalProducts</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Enable automatic fulfillment for all digital products
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultDigitalMaxDownloads</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Default number of max downloads per digital content url
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultDigitalUrlValidDays</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Default number of days which digital content url will be valid
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShopSettingsTranslationInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>headerText</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SiteDomainInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>domain</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Domain name for shop
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Shop site name
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### StaffCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Family name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The unique email address of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+User account is active.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>note</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+A note about the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>permissions</strong></td>
+<td valign="top">[<a href="#permissionenum">PermissionEnum</a>]</td>
+<td>
+
+List of permission code names to assign to this user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sendPasswordEmail</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Send an email with a link to set the password
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>redirectUrl</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+('URL of a view where users should be redirected to set the password. URL in RFC 1808 format.',)
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### StaffInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Family name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The unique email address of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+User account is active.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>note</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+A note about the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>permissions</strong></td>
+<td valign="top">[<a href="#permissionenum">PermissionEnum</a>]</td>
+<td>
+
+List of permission code names to assign to this user.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### StaffUserInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top"><a href="#staffmemberstatus">StaffMemberStatus</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TranslationInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>seoTitle</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>seoDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>description</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>descriptionJson</strong></td>
+<td valign="top"><a href="#jsonstring">JSONString</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserAddressInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>defaultBillingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultShippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### UserCreateInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>defaultBillingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Billing address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>defaultShippingAddress</strong></td>
+<td valign="top"><a href="#addressinput">AddressInput</a></td>
+<td>
+
+Shipping address of the customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>firstName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Family name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+The unique email address of the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+User account is active.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>note</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+A note about the user.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sendPasswordEmail</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Send an email with a link to set a password
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>redirectUrl</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+('URL of a view where users should be redirected to set the password. URL in RFC 1808 format.',)
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### VoucherFilterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top">[<a href="#discountstatusenum">DiscountStatusEnum</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>timesUsed</strong></td>
+<td valign="top"><a href="#intrangeinput">IntRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountType</strong></td>
+<td valign="top">[<a href="#voucherdiscounttype">VoucherDiscountType</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>started</strong></td>
+<td valign="top"><a href="#datetimerangeinput">DateTimeRangeInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>search</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VoucherInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#vouchertypeenum">VoucherTypeEnum</a></td>
+<td>
+
+Voucher type: PRODUCT, CATEGORY SHIPPING or ENTIRE_ORDER.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Voucher name.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+Start date of the voucher in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endDate</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+End date of the voucher in ISO 8601 format.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountValueType</strong></td>
+<td valign="top"><a href="#discountvaluetypeenum">DiscountValueTypeEnum</a></td>
+<td>
+
+Choices: fixed or percentage.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>discountValue</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Value of the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>products</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Products discounted by the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>collections</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Collections discounted by the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categories</strong></td>
+<td valign="top">[<a href="#id">ID</a>]</td>
+<td>
+
+Categories discounted by the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minAmountSpent</strong></td>
+<td valign="top"><a href="#decimal">Decimal</a></td>
+<td>
+
+Min purchase amount required to apply the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>minCheckoutItemsQuantity</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Minimal quantity of checkout items required to apply the voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>countries</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td>
+
+Country codes that can be used with the shipping voucher.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>applyOncePerOrder</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Voucher should be applied to the cheapest item or entire order.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>applyOncePerCustomer</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Voucher should be applied once per customer.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>usageLimit</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+Limit number of times this voucher can be used in total
+
+</td>
+</tr>
+</tbody>
+</table>
+
+## Enums
+
+### AccountErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACTIVATE_OWN_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ACTIVATE_SUPERUSER_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DEACTIVATE_OWN_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DEACTIVATE_SUPERUSER_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DELETE_NON_STAFF_USER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DELETE_OWN_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DELETE_STAFF_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DELETE_SUPERUSER_ACCOUNT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID_PASSWORD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSWORD_ENTIRELY_NUMERIC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSWORD_TOO_COMMON</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSWORD_TOO_SHORT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSWORD_TOO_SIMILAR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AddressTypeEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>BILLING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeInputTypeEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>DROPDOWN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MULTISELECT</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeSortField
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>NAME</strong></td>
+<td>
+
+Sort attributes by name.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>SLUG</strong></td>
+<td>
+
+Sort attributes by slug.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>VALUE_REQUIRED</strong></td>
+<td>
+
+Sort attributes by the value required flag.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>IS_VARIANT_ONLY</strong></td>
+<td>
+
+Sort attributes by the variant only flag.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>VISIBLE_IN_STOREFRONT</strong></td>
+<td>
+
+Sort attributes by visibility in the storefront.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>FILTERABLE_IN_STOREFRONT</strong></td>
+<td>
+
+Sort attributes by the filterable in storefront flag.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>FILTERABLE_IN_DASHBOARD</strong></td>
+<td>
+
+Sort attributes by the filterable in dashboard flag.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>DASHBOARD_VARIANT_POSITION</strong></td>
+<td>
+
+Sort variant attributes by their position in dashboard.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>DASHBOARD_PRODUCT_POSITION</strong></td>
+<td>
+
+Sort product attributes by their position in dashboard.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>STOREFRONT_SEARCH_POSITION</strong></td>
+<td>
+
+Sort attributes by their position in storefront.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>AVAILABLE_IN_GRID</strong></td>
+<td>
+
+Sort attributes based on whether they can be displayed or not in a product grid.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### AttributeTypeEnum
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PRODUCT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VARIANT</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AttributeValueType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>COLOR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRADIENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>URL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>STRING</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AuthorizationKeyType
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>FACEBOOK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GOOGLE_OAUTH2</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CheckoutErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>BILLING_ADDRESS_NOT_SET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CHECKOUT_NOT_FULLY_PAID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INSUFFICIENT_STOCK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID_SHIPPING_METHOD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>QUANTITY_GREATER_THAN_LIMIT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_ADDRESS_NOT_SET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_METHOD_NOT_APPLICABLE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_METHOD_NOT_SET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_NOT_REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TAX_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VOUCHER_NOT_APPLICABLE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZERO_QUANTITY</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CollectionPublished
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PUBLISHED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HIDDEN</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ConfigurationTypeFieldEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>STRING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BOOLEAN</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CountryCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>AF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AX</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AQ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BB</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BJ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BQ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CX</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DJ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GQ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FJ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GP</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IQ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>JM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>JP</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>JE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>JO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LB</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ML</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MQ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>YT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MX</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ME</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NP</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KP</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MP</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>QA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ST</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SX</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SB</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SJ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TJ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TC</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GB</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>US</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>YE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZW</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CustomerEventsEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACCOUNT_CREATED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSWORD_RESET_LINK_SENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSWORD_RESET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PLACED_ORDER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOTE_ADDED_TO_ORDER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DIGITAL_LINK_DOWNLOADED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CUSTOMER_DELETED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NAME_ASSIGNED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EMAIL_ASSIGNED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOTE_ADDED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DiscountStatusEnum
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACTIVE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EXPIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SCHEDULED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### DiscountValueTypeEnum
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>FIXED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PERCENTAGE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ExtensionsErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PLUGIN_MISCONFIGURED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FulfillmentStatus
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>FULFILLED</strong></td>
+<td>
+
+Fulfilled
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>CANCELED</strong></td>
+<td>
+
+Canceled
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### GatewaysEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>DUMMY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BRAINTREE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RAZORPAY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>STRIPE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### GiftCardErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ALREADY_EXISTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### LanguageCodeEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>AR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ES_CO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>JA</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>KO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NB</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PT_BR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RO</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RU</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SQ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SW</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TH</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VI</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZH_HANS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZH_HANT</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MenuErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>CANNOT_ASSIGN_NODE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID_MENU_ITEM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NO_MENU_ITEM_PROVIDED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TOO_MANY_MENU_ITEMS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### NavigationType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>MAIN</strong></td>
+<td>
+
+Main storefront's navigation.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>SECONDARY</strong></td>
+<td>
+
+Secondary storefront's navigation.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderAction
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>CAPTURE</strong></td>
+<td>
+
+Represents the capture action.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>MARK_AS_PAID</strong></td>
+<td>
+
+Represents a mark-as-paid action.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>REFUND</strong></td>
+<td>
+
+Represents a refund action.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>VOID</strong></td>
+<td>
+
+Represents a void action.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderDirection
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ASC</strong></td>
+<td>
+
+Specifies an ascending sort order.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>DESC</strong></td>
+<td>
+
+Specifies a descending sort order.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>CANNOT_CANCEL_FULFILLMENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CANNOT_CANCEL_ORDER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CANNOT_DELETE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CANNOT_REFUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CAPTURE_INACTIVE_PAYMENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_EDITABLE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILL_ORDER_LINE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ORDER_NO_SHIPPING_ADDRESS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_MISSING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_METHOD_NOT_APPLICABLE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_METHOD_REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VOID_INACTIVE_PAYMENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ZERO_QUANTITY</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderEventsEmailsEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PAYMENT_CONFIRMATION</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_CONFIRMATION</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRACKING_UPDATED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ORDER_CONFIRMATION</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILLMENT_CONFIRMATION</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DIGITAL_LINKS</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderEventsEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>DRAFT_CREATED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DRAFT_ADDED_PRODUCTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DRAFT_REMOVED_PRODUCTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PLACED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PLACED_FROM_DRAFT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OVERSOLD_ITEMS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CANCELED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ORDER_MARKED_AS_PAID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ORDER_FULLY_PAID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UPDATED_ADDRESS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>EMAIL_SENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_CAPTURED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_REFUNDED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_VOIDED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_FAILED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILLMENT_CANCELED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILLMENT_RESTOCKED_ITEMS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILLMENT_FULFILLED_ITEMS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRACKING_UPDATED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOTE_ADDED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OTHER</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### OrderStatus
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>DRAFT</strong></td>
+<td>
+
+Draft
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>UNFULFILLED</strong></td>
+<td>
+
+Unfulfilled
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>PARTIALLY_FULFILLED</strong></td>
+<td>
+
+Partially fulfilled
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILLED</strong></td>
+<td>
+
+Fulfilled
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>CANCELED</strong></td>
+<td>
+
+Canceled
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### OrderStatusFilter
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>READY_TO_FULFILL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>READY_TO_CAPTURE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNFULFILLED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PARTIALLY_FULFILLED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULFILLED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CANCELED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PaymentChargeStatusEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>NOT_CHARGED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PARTIALLY_CHARGED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULLY_CHARGED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PARTIALLY_REFUNDED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FULLY_REFUNDED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PaymentErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>BILLING_ADDRESS_NOT_SET</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PARTIAL_PAYMENT_NOT_ALLOWED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAYMENT_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PermissionEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>MANAGE_USERS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_STAFF</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_SERVICE_ACCOUNTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>IMPERSONATE_USERS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_DISCOUNTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_GIFT_CARD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_PLUGINS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_MENUS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_ORDERS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_PAGES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_PRODUCTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_SHIPPING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_SETTINGS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MANAGE_TRANSLATIONS</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ALREADY_EXISTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ATTRIBUTE_ALREADY_ASSIGNED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ATTRIBUTE_CANNOT_BE_ASSIGNED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ATTRIBUTE_VARIANTS_DISABLED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_PRODUCTS_IMAGE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VARIANT_NO_DIGITAL_CONTENT</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductOrderField
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>NAME</strong></td>
+<td>
+
+Sort products by name.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>PRICE</strong></td>
+<td>
+
+Sort products by price.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>MINIMAL_PRICE</strong></td>
+<td>
+
+Sort products by a minimal price of a product's variant.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>DATE</strong></td>
+<td>
+
+Sort products by update date.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TYPE</strong></td>
+<td>
+
+Sort products by type.
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>PUBLISHED</strong></td>
+<td>
+
+Sort products by publication status.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeConfigurable
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>CONFIGURABLE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SIMPLE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProductTypeEnum
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>DIGITAL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPABLE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ReportingPeriod
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>TODAY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>THIS_MONTH</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SaleType
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>FIXED</strong></td>
+<td>
+
+USD
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>PERCENTAGE</strong></td>
+<td>
+
+%
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ShippingErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ALREADY_EXISTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MAX_LESS_THAN_MIN</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShippingMethodTypeEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PRICE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WEIGHT</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ShopErrorCode
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ALREADY_EXISTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CANNOT_FETCH_TAX_RATES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRAPHQL_ERROR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>INVALID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_FOUND</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REQUIRED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>UNIQUE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StaffMemberStatus
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACTIVE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DEACTIVATED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StockAvailability
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>IN_STOCK</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OUT_OF_STOCK</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TaxRateType
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACCOMMODATION</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ADMISSION_TO_CULTURAL_EVENTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ADMISSION_TO_ENTERTAINMENT_EVENTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ADMISSION_TO_SPORTING_EVENTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ADVERTISING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AGRICULTURAL_SUPPLIES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BABY_FOODSTUFFS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BIKES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BOOKS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CHILDRENS_CLOTHING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DOMESTIC_FUEL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DOMESTIC_SERVICES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>E_BOOKS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>FOODSTUFFS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>HOTELS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MEDICAL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NEWSPAPERS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PASSENGER_TRANSPORT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PHARMACEUTICALS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PROPERTY_RENOVATIONS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RESTAURANTS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SOCIAL_HOUSING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>STANDARD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WATER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WINE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TransactionError
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INCORRECT_NUMBER</strong></td>
+<td>
+
+incorrect_number
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INVALID_NUMBER</strong></td>
+<td>
+
+invalid_number
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INCORRECT_CVV</strong></td>
+<td>
+
+incorrect_cvv
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INVALID_CVV</strong></td>
+<td>
+
+invalid_cvv
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INCORRECT_ZIP</strong></td>
+<td>
+
+incorrect_zip
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INCORRECT_ADDRESS</strong></td>
+<td>
+
+incorrect_address
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_INVALID_EXPIRY_DATE</strong></td>
+<td>
+
+invalid_expiry_date
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_EXPIRED</strong></td>
+<td>
+
+expired
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_PROCESSING_ERROR</strong></td>
+<td>
+
+processing_error
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSACTIONERROR_DECLINED</strong></td>
+<td>
+
+declined
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### TransactionKind
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>AUTH</strong></td>
+<td>
+
+Authorization
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>REFUND</strong></td>
+<td>
+
+Refund
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>CAPTURE</strong></td>
+<td>
+
+Capture
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>VOID</strong></td>
+<td>
+
+Void
+
+</td>
+</tr>
+<tr>
+<td valign="top"><strong>CONFIRM</strong></td>
+<td>
+
+Confirm
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### TranslatableKinds
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ATTRIBUTE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ATTRIBUTE_VALUE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CATEGORY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>COLLECTION</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>MENU_ITEM</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PAGE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PRODUCT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SALE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING_METHOD</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VARIANT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>VOUCHER</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VoucherDiscountType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>FIXED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PERCENTAGE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SHIPPING</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### VoucherTypeEnum
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>SHIPPING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ENTIRE_ORDER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SPECIFIC_PRODUCT</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### WeightUnitsEnum
+
+An enumeration.
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>KG</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LB</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OZ</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>G</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Scalars
+
+### AttributeScalar
+
+### Boolean
+
+The `Boolean` scalar type represents `true` or `false`.
+
+### Date
+
+The `Date` scalar type represents a Date
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+
+### DateTime
+
+The `DateTime` scalar type represents a DateTime
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+
+### Decimal
+
+Custom Decimal implementation.
+
+Returns Decimal as a float in the API,
+parses float to the Decimal on the way back.
+
+### Float
+
+The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). 
+
+### GenericScalar
+
+The `GenericScalar` scalar type represents a generic
+GraphQL scalar value that could be:
+String, Boolean, Int, Float, List or Object.
+
+### ID
+
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+
+### Int
+
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31 - 1) and 2^31 - 1 since represented in JSON as double-precision floating point numbers specifiedby [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
+
+### JSONString
+
+Allows use of a JSON String for input / output from the GraphQL schema.
+
+Use of this type is *not recommended* as you lose the benefits of having a defined, static
+schema (one of the key benefits of GraphQL).
+
+### String
+
+The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+
+### UUID
+
+Leverages the internal Python implmeentation of UUID (uuid.UUID) to provide native UUID objects
+in fields, resolvers and input.
+
+### Upload
+
+Variables of this type must be set to null in
+        mutations. They will be replaced with a filename from a following
+        multipart part containing a binary file. See:
+        https://github.com/jaydenseric/graphql-multipart-request-spec
+
+### WeightScalar
+
+
+## Interfaces
+
+
+### Node
+
+An object with an ID
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+The ID of the object.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+<!-- END graphql-markdown -->

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -562,7 +562,7 @@ Kind of objects to retrieve.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -571,7 +571,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -580,7 +580,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -589,7 +589,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -634,7 +634,7 @@ List of the shop's shipping zones.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -643,7 +643,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -652,7 +652,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -661,7 +661,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -697,7 +697,7 @@ List of the digital contents.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -706,7 +706,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -715,7 +715,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -724,7 +724,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -791,7 +791,7 @@ Sorting options for attributes.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -800,7 +800,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -809,7 +809,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -818,7 +818,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -883,7 +883,7 @@ Filter categories by the nesting level in the category tree.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -892,7 +892,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -901,7 +901,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -910,7 +910,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -984,7 +984,7 @@ Supported filter parameters:
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -993,7 +993,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1002,7 +1002,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1011,7 +1011,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1112,7 +1112,7 @@ Supported filter parameters:
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1121,7 +1121,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1130,7 +1130,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1139,7 +1139,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1195,7 +1195,7 @@ Supported filter parameters:
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1204,7 +1204,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1213,7 +1213,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1222,7 +1222,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1267,7 +1267,7 @@ Filter product variants by given IDs.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1276,7 +1276,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1285,7 +1285,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1294,7 +1294,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1321,7 +1321,7 @@ Span of time.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1330,7 +1330,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1339,7 +1339,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1348,7 +1348,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1384,7 +1384,7 @@ List of payments
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1393,7 +1393,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1402,7 +1402,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1411,7 +1411,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1494,7 +1494,7 @@ Filtering options for pages.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1503,7 +1503,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1512,7 +1512,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1521,7 +1521,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1540,7 +1540,7 @@ List of activity events to display on
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1549,7 +1549,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1558,7 +1558,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1567,7 +1567,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1641,7 +1641,7 @@ Filter order by status
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1650,7 +1650,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1659,7 +1659,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1668,7 +1668,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1715,7 +1715,7 @@ Filter draft orders from a selected timespan.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1724,7 +1724,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1733,7 +1733,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1742,7 +1742,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1843,7 +1843,7 @@ Filtering options for menus.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1852,7 +1852,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1861,7 +1861,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1870,7 +1870,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1926,7 +1926,7 @@ Filtering options for menu items.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1935,7 +1935,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -1944,7 +1944,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -1953,7 +1953,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -1989,7 +1989,7 @@ List of gift cards
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -1998,7 +1998,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2007,7 +2007,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2016,7 +2016,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2061,7 +2061,7 @@ Filtering options for plugins
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2070,7 +2070,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2079,7 +2079,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2088,7 +2088,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2142,7 +2142,7 @@ Search sales by name, value or type.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2151,7 +2151,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2160,7 +2160,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2169,7 +2169,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2223,7 +2223,7 @@ Search vouchers by name or code.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2232,7 +2232,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2241,7 +2241,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2250,7 +2250,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2295,7 +2295,7 @@ List of checkouts.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2304,7 +2304,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2313,7 +2313,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2322,7 +2322,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2358,7 +2358,7 @@ List of checkout lines
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2367,7 +2367,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2376,7 +2376,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2385,7 +2385,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2468,7 +2468,7 @@ Supported filter parameters:
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2477,7 +2477,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2486,7 +2486,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2495,7 +2495,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2542,7 +2542,7 @@ Supported filter parameters:
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2551,7 +2551,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2560,7 +2560,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2569,7 +2569,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2596,7 +2596,7 @@ Filtering options for service accounts.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -2605,7 +2605,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -2614,7 +2614,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -2623,7 +2623,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -2650,7 +2650,7 @@ ID of the service account.
 <td valign="top"><a href="#user">User</a></td>
 <td>
 
-Lookup an user by ID.
+Lookup a user by ID.
 
 </td>
 </tr>
@@ -9959,7 +9959,7 @@ List of ancestors of the category.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -9968,7 +9968,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -9977,7 +9977,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -9986,7 +9986,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -10004,7 +10004,7 @@ List of products in the category.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -10013,7 +10013,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -10022,7 +10022,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -10031,7 +10031,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -10058,7 +10058,7 @@ List of children of the category.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -10067,7 +10067,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -10076,7 +10076,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -10085,7 +10085,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -11896,7 +11896,7 @@ List of products in this collection.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -11905,7 +11905,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -11914,7 +11914,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -11923,7 +11923,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -19288,7 +19288,7 @@ List of products of this type.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -19297,7 +19297,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -19306,7 +19306,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -19315,7 +19315,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -19370,7 +19370,7 @@ Product attributes of that product type.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -19379,7 +19379,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -19388,7 +19388,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -19397,7 +19397,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -20742,7 +20742,7 @@ List of categories this sale applies to.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -20751,7 +20751,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -20760,7 +20760,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -20769,7 +20769,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -20787,7 +20787,7 @@ List of collections this sale applies to.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -20796,7 +20796,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -20805,7 +20805,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -20814,7 +20814,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -20832,7 +20832,7 @@ List of products this sale applies to.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -20841,7 +20841,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -20850,7 +20850,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -20859,7 +20859,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -21650,7 +21650,7 @@ Sets the user's password from the token sent by email using the RequestPasswordR
 <td valign="top"><a href="#user">User</a></td>
 <td>
 
-An user instance with new password.
+A user instance with new password.
 
 </td>
 </tr>
@@ -23416,7 +23416,7 @@ List of the user gift cards.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -23425,7 +23425,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -23434,7 +23434,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -23443,7 +23443,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -23461,7 +23461,7 @@ List of user's orders.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -23470,7 +23470,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -23479,7 +23479,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -23488,7 +23488,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -24228,7 +24228,7 @@ List of categories this voucher applies to.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -24237,7 +24237,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -24246,7 +24246,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -24255,7 +24255,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -24273,7 +24273,7 @@ List of collections this voucher applies to.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -24282,7 +24282,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -24291,7 +24291,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -24300,7 +24300,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -24318,7 +24318,7 @@ List of products this voucher applies to.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come before the specified cursor.
+Return the elements in the list that come before the specified cursor.
 
 </td>
 </tr>
@@ -24327,7 +24327,7 @@ Returns the elements in the list that come before the specified cursor.
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Returns the elements in the list that come after the specified cursor.
+Return the elements in the list that come after the specified cursor.
 
 </td>
 </tr>
@@ -24336,7 +24336,7 @@ Returns the elements in the list that come after the specified cursor.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the first n elements from the list.
+Return the first n elements from the list.
 
 </td>
 </tr>
@@ -24345,7 +24345,7 @@ Returns the first n elements from the list.
 <td valign="top"><a href="#int">Int</a></td>
 <td>
 
-Returns the last n elements from the list.
+Return the last n elements from the list.
 
 </td>
 </tr>
@@ -28070,10 +28070,20 @@ Determines if the inventory of this product
 <tbody>
 <tr>
 <td colspan="2" valign="top"><strong>field</strong></td>
-<td valign="top"><a href="#productorderfield">ProductOrderField</a>!</td>
+<td valign="top"><a href="#productorderfield">ProductOrderField</a></td>
 <td>
 
 Sort products by the selected field.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>attributeId</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td>
+
+Sort product by the selected attribute's values.
+Note: this doesn't take translations into account yet.
 
 </td>
 </tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,9 @@ title: Welcome to Saleor Docs
 [![](assets/icons/niema) **Guides** How to effectively create and complete a checkout and obtain products.](api-process/intro.md)
 [/home-grid]
 
+[home-grid]
+[![](assets/icons/niema) **API Reference** A reference of every data type and operation in Saleor GraphQL API.](api-reference.md)
+[/home-grid]
 
 
 ## Running your Saleor Server

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,9602 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
+      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0",
+        "esutils": "^2.0.0"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
+      "integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.2.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
+      "integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+      "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
+      "integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+      "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+      "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+      "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+      "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
+      "integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+      "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
+      "integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+      "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+      "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+      "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
+      "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+      "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+      "integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "^0.1.6"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.4.4",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+      "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+      "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+      "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.0"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+      "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+      "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+      "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
+      }
+    },
+    "@babel/polyfill": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
+      "integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
+        "@babel/plugin-proposal-json-strings": "^7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-transform-arrow-functions": "^7.2.0",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+        "@babel/plugin-transform-block-scoping": "^7.5.5",
+        "@babel/plugin-transform-classes": "^7.5.5",
+        "@babel/plugin-transform-computed-properties": "^7.2.0",
+        "@babel/plugin-transform-destructuring": "^7.5.0",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+        "@babel/plugin-transform-for-of": "^7.4.4",
+        "@babel/plugin-transform-function-name": "^7.4.4",
+        "@babel/plugin-transform-literals": "^7.2.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
+        "@babel/plugin-transform-modules-umd": "^7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+        "@babel/plugin-transform-new-target": "^7.4.4",
+        "@babel/plugin-transform-object-super": "^7.5.5",
+        "@babel/plugin-transform-parameters": "^7.4.4",
+        "@babel/plugin-transform-property-literals": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.4.5",
+        "@babel/plugin-transform-reserved-words": "^7.2.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+        "@babel/plugin-transform-spread": "^7.2.0",
+        "@babel/plugin-transform-sticky-regex": "^7.2.0",
+        "@babel/plugin-transform-template-literals": "^7.4.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+        "@babel/plugin-transform-unicode-regex": "^7.4.4",
+        "@babel/types": "^7.5.5",
+        "browserslist": "^4.6.0",
+        "core-js-compat": "^3.1.1",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.5.0"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
+      "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+      }
+    },
+    "@babel/register": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.5.5.tgz",
+      "integrity": "sha512-pdd5nNR+g2qDkXZlW1yRCWFlNrAn2PPdnZUB72zjX4l1Vv4fMRRLwyf+n/idFCLI1UgVGboUU8oVziwTBiyNKQ==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.0.0",
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.1",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.9"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/types": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
+    },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
+    },
+    "@types/cheerio": {
+      "version": "0.22.13",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.13.tgz",
+      "integrity": "sha512-OZd7dCUOUkiTorf97vJKwZnSja/DmHfuBAroe1kREZZTCf/tlFecwHhsOos3uVHxeKGZDwzolIrCUApClkdLuA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "dev": true
+    },
+    "@types/q": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "address": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.1.0.tgz",
+      "integrity": "sha512-4diPfzWbLEIElVG4AnqP+00SULlPzNuyJFNnmMrLgyaxG6tZXJ1sn7mjBu4fHrJE+Yp/jgylOweJn2xsLMFggQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz",
+      "integrity": "sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "dev": true
+    },
+    "archive-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
+      "integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
+      "dev": true,
+      "requires": {
+        "file-type": "^4.2.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
+          "dev": true
+        }
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "dev": true,
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
+    },
+    "autoprefixer": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
+      "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.6.3",
+        "caniuse-lite": "^1.0.30000980",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.17",
+        "postcss-value-parser": "^4.0.0"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
+    },
+    "bin-build": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
+      "integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
+      "dev": true,
+      "requires": {
+        "decompress": "^4.0.0",
+        "download": "^6.2.2",
+        "execa": "^0.7.0",
+        "p-map-series": "^1.0.0",
+        "tempfile": "^2.0.0"
+      }
+    },
+    "bin-check": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
+      "integrity": "sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0",
+        "executable": "^4.1.0"
+      }
+    },
+    "bin-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.1.0.tgz",
+      "integrity": "sha512-Mkfm4iE1VFt4xd4vH+gx+0/71esbfus2LsnCGe8Pi4mndSPyT+NGES/Eg99jx8/lUGWfu3z2yuB/bt5UB+iVbQ==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "find-versions": "^3.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "bin-version-check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-4.0.0.tgz",
+      "integrity": "sha512-sR631OrhC+1f8Cvs8WyVWOA33Y8tgwjETNPyyD/myRBXLkfS/vl74FmH/lFcRl9KY3zwGh7jFhvyk9vV3/3ilQ==",
+      "dev": true,
+      "requires": {
+        "bin-version": "^3.0.0",
+        "semver": "^5.6.0",
+        "semver-truncate": "^1.1.2"
+      }
+    },
+    "bin-wrapper": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-4.1.0.tgz",
+      "integrity": "sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==",
+      "dev": true,
+      "requires": {
+        "bin-check": "^4.1.0",
+        "bin-version-check": "^4.0.0",
+        "download": "^7.1.0",
+        "import-lazy": "^3.1.0",
+        "os-filter-obj": "^2.0.0",
+        "pify": "^4.0.1"
+      },
+      "dependencies": {
+        "download": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
+          "integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
+          "dev": true,
+          "requires": {
+            "archive-type": "^4.0.0",
+            "caw": "^2.0.1",
+            "content-disposition": "^0.5.2",
+            "decompress": "^4.2.0",
+            "ext-name": "^5.0.0",
+            "file-type": "^8.1.0",
+            "filenamify": "^2.0.0",
+            "get-stream": "^3.0.0",
+            "got": "^8.3.1",
+            "make-dir": "^1.2.0",
+            "p-event": "^2.1.0",
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "file-type": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+          "dev": true
+        },
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+          "dev": true
+        },
+        "p-event": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+          "integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
+          "dev": true,
+          "requires": {
+            "p-timeout": "^2.0.1"
+          }
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+          "dev": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "body": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+      "dev": true,
+      "requires": {
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+          "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+          "dev": true,
+          "requires": {
+            "bytes": "1",
+            "string_decoder": "0.10"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
+      }
+    },
+    "buffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
+      "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        }
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000989",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "caw": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+      "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+      "dev": true,
+      "requires": {
+        "get-proxy": "^2.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "tunnel-agent": "^0.6.0",
+        "url-to-options": "^1.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+      "dev": true,
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash.assignin": "^4.0.9",
+        "lodash.bind": "^4.1.4",
+        "lodash.defaults": "^4.0.1",
+        "lodash.filter": "^4.4.0",
+        "lodash.flatten": "^4.2.0",
+        "lodash.foreach": "^4.3.0",
+        "lodash.map": "^4.4.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.pick": "^4.2.1",
+        "lodash.reduce": "^4.4.0",
+        "lodash.reject": "^4.4.0",
+        "lodash.some": "^4.4.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+          "dev": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+          "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "entities": "^1.1.1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
+      "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+      "dev": true,
+      "requires": {
+        "anymatch": "^3.0.1",
+        "braces": "^3.0.2",
+        "fsevents": "^2.0.6",
+        "glob-parent": "^5.0.0",
+        "is-binary-path": "^2.1.0",
+        "is-glob": "^4.0.1",
+        "normalize-path": "^3.0.0",
+        "readdirp": "^3.1.1"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "coa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+      "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+      "dev": true,
+      "requires": {
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
+      }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+      "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "console-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+      "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "crowdin-cli": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/crowdin-cli/-/crowdin-cli-0.3.0.tgz",
+      "integrity": "sha1-6smYmm/n/qrzMJA5evwYfGe0YZE=",
+      "dev": true,
+      "requires": {
+        "request": "^2.53.0",
+        "yamljs": "^0.2.1",
+        "yargs": "^2.3.0"
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-declaration-sorter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
+      }
+    },
+    "css-select": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
+      "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^2.1.2",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
+      }
+    },
+    "css-select-base-adapter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+      "dev": true
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.5.3"
+      }
+    },
+    "css-unit-converter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+      "dev": true
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+      "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+      "integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.7",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
+      }
+    },
+    "cssnano-preset-default": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+      "integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+      "dev": true,
+      "requires": {
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.2",
+        "postcss-unique-selectors": "^4.0.1"
+      }
+    },
+    "cssnano-util-get-arguments": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+      "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+      "dev": true
+    },
+    "cssnano-util-get-match": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+      "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+      "dev": true
+    },
+    "cssnano-util-raw-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+      "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "cssnano-util-same-parent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+      "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
+      "dev": true
+    },
+    "csso": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+      "dev": true,
+      "requires": {
+        "css-tree": "1.0.0-alpha.29"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.0.0-alpha.29",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+          "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+          "dev": true,
+          "requires": {
+            "mdn-data": "~1.1.0",
+            "source-map": "^0.5.3"
+          }
+        },
+        "mdn-data": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+          "dev": true
+        }
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "decompress": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "dev": true,
+      "requires": {
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "dev": true
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "dev": true,
+      "requires": {
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-port-alt": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+      "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
+      "dev": true,
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68=",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
+      }
+    },
+    "docusaurus": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/docusaurus/-/docusaurus-1.12.0.tgz",
+      "integrity": "sha512-C8HUDctWn72JOxqwnP6/+fUUQFADIjNw9Tvgw9CBlXLVN6CUhuTrk3YShM5EjZILjIrcmReoHcy6lCDkCa2X8Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.5.5",
+        "@babel/plugin-proposal-class-properties": "^7.5.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+        "@babel/polyfill": "^7.4.4",
+        "@babel/preset-env": "^7.5.5",
+        "@babel/preset-react": "^7.0.0",
+        "@babel/register": "^7.5.5",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "autoprefixer": "^9.6.0",
+        "babylon": "^6.18.0",
+        "chalk": "^2.4.2",
+        "chokidar": "^3.0.2",
+        "classnames": "^2.2.6",
+        "color": "^2.0.1",
+        "commander": "^2.20.0",
+        "cross-spawn": "^6.0.5",
+        "crowdin-cli": "^0.3.0",
+        "cssnano": "^4.1.0",
+        "escape-string-regexp": "^2.0.0",
+        "express": "^4.17.1",
+        "feed": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "gaze": "^1.1.3",
+        "glob": "^7.1.3",
+        "highlight.js": "^9.15.8",
+        "imagemin": "^6.0.0",
+        "imagemin-gifsicle": "^6.0.1",
+        "imagemin-jpegtran": "^6.0.0",
+        "imagemin-optipng": "^6.0.0",
+        "imagemin-svgo": "^7.0.0",
+        "lodash": "^4.17.14",
+        "markdown-toc": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "portfinder": "^1.0.21",
+        "postcss": "^7.0.17",
+        "prismjs": "^1.16.0",
+        "react": "^16.8.4",
+        "react-dev-utils": "^9.0.1",
+        "react-dom": "^16.8.4",
+        "remarkable": "^1.7.1",
+        "request": "^2.88.0",
+        "shelljs": "^0.8.3",
+        "sitemap": "^3.2.2",
+        "tcp-port-used": "^1.0.1",
+        "tiny-lr": "^1.1.1",
+        "tree-node-cli": "^1.2.5",
+        "truncate-html": "^1.0.1"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "download": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+      "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+      "dev": true,
+      "requires": {
+        "caw": "^2.0.0",
+        "content-disposition": "^0.5.2",
+        "decompress": "^4.0.0",
+        "ext-name": "^5.0.0",
+        "file-type": "5.2.0",
+        "filenamify": "^2.0.0",
+        "get-stream": "^3.0.0",
+        "got": "^7.0.0",
+        "make-dir": "^1.0.0",
+        "p-event": "^1.0.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.241",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.241.tgz",
+      "integrity": "sha512-Gb9E6nWZlbgjDDNe5cAvMJixtn79krNJ70EDpq/M10lkGo7PGtBUe7Y0CYVHsBScRwi6ybCS+YetXAN9ysAHDg==",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+      "dev": true
+    },
+    "error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+      "dev": true,
+      "requires": {
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        }
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
+    "exec-buffer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+      "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0",
+        "p-finally": "^1.0.0",
+        "pify": "^3.0.0",
+        "rimraf": "^2.5.4",
+        "tempfile": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
+    "executable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "dev": true,
+      "requires": {
+        "pify": "^2.2.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      },
+      "dependencies": {
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
+    },
+    "ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "dev": true,
+      "requires": {
+        "mime-db": "^1.28.0"
+      }
+    },
+    "ext-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "dev": true,
+      "requires": {
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "feed": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-1.1.1.tgz",
+      "integrity": "sha1-kUiXUX6U+jJ8xvc7tYWkfEqe0yE=",
+      "dev": true,
+      "requires": {
+        "xml": "^1.0.1"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "file-type": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
+      "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.1.0.tgz",
+      "integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^2.1.0",
+        "semver-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "array-uniq": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+          "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
+          "dev": true
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "fork-ts-checker-webpack-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.5.0.tgz",
+      "integrity": "sha512-zEhg7Hz+KhZlBhILYpXy+Beu96gwvkROWJiTXOCyOOMMrdBIRPvsBpBqgTI4jfJGrJXcqGwJR8zsBGDmzY0jsA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.4.1",
+        "chokidar": "^2.0.4",
+        "micromatch": "^3.1.10",
+        "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
+        "tapable": "^1.0.0",
+        "worker-rpc": "^0.1.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+              "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+              "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+              "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+              "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.12.0",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+              "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+              "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+              "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+              "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+      "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "dev": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
+    },
+    "get-proxy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+      "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+      "dev": true,
+      "requires": {
+        "npm-conf": "^1.1.0"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "gifsicle": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-4.0.1.tgz",
+      "integrity": "sha512-A/kiCLfDdV+ERV/UB+2O41mifd+RxH8jlRG8DMxZO84Bma/Fw0htqZ+hY2iaalLRNyUu7tYZQslqUBJxBggxbg==",
+      "dev": true,
+      "requires": {
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.0",
+        "execa": "^1.0.0",
+        "logalot": "^2.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "globby": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "dir-glob": "2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "globule": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
+    "got": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0",
+        "url-to-options": "^1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "graphql": {
+      "version": "14.5.7",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.7.tgz",
+      "integrity": "sha512-as410RMJSUFqF8RcH2QWxZ5ioqHzsH9VWnWbaU+UnDXJ/6azMDIYPrtXCBPXd8rlunEVb7W8z6fuUnNHMbFu9A==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-markdown": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-markdown/-/graphql-markdown-5.0.1.tgz",
+      "integrity": "sha512-PfhVfvih2n3GH6/8feFQkE8GFlE8yJyDbQYtacLf2NLpxL0T2tAsKwCTkuab8tYh/2yMpNtuPA9hNIqGoBz1aA==",
+      "requires": {
+        "deep-diff": "^1.0.2",
+        "graphql": "^14.0.2",
+        "lodash.isplainobject": "^4.0.6",
+        "minimist": "^1.2.0",
+        "node-fetch": "^2.2.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
+    "gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+      "dev": true,
+      "requires": {
+        "ansi-red": "^0.1.1",
+        "coffee-script": "^1.12.4",
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.8.1",
+        "toml": "^2.3.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "dev": true,
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "gzip-size": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hex-color-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
+    },
+    "hsl-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+      "dev": true
+    },
+    "hsla-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+      "dev": true
+    },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imagemin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-6.1.0.tgz",
+      "integrity": "sha512-8ryJBL1CN5uSHpiBMX0rJw79C9F9aJqMnjGnrd/1CafegpNuA81RBAAru/jQQEOWlOJJlpRnlcVFF6wq+Ist0A==",
+      "dev": true,
+      "requires": {
+        "file-type": "^10.7.0",
+        "globby": "^8.0.1",
+        "make-dir": "^1.0.0",
+        "p-pipe": "^1.1.0",
+        "pify": "^4.0.1",
+        "replace-ext": "^1.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "imagemin-gifsicle": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-6.0.1.tgz",
+      "integrity": "sha512-kuu47c6iKDQ6R9J10xCwL0lgs0+sMz3LRHqRcJ2CRBWdcNmo3T5hUaM8hSZfksptZXJLGKk8heSAvwtSdB1Fng==",
+      "dev": true,
+      "requires": {
+        "exec-buffer": "^3.0.0",
+        "gifsicle": "^4.0.0",
+        "is-gif": "^3.0.0"
+      }
+    },
+    "imagemin-jpegtran": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-6.0.0.tgz",
+      "integrity": "sha512-Ih+NgThzqYfEWv9t58EItncaaXIHR0u9RuhKa8CtVBlMBvY0dCIxgQJQCfwImA4AV1PMfmUKlkyIHJjb7V4z1g==",
+      "dev": true,
+      "requires": {
+        "exec-buffer": "^3.0.0",
+        "is-jpg": "^2.0.0",
+        "jpegtran-bin": "^4.0.0"
+      }
+    },
+    "imagemin-optipng": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-6.0.0.tgz",
+      "integrity": "sha512-FoD2sMXvmoNm/zKPOWdhKpWdFdF9qiJmKC17MxZJPH42VMAp17/QENI/lIuP7LCUnLVAloO3AUoTSNzfhpyd8A==",
+      "dev": true,
+      "requires": {
+        "exec-buffer": "^3.0.0",
+        "is-png": "^1.0.0",
+        "optipng-bin": "^5.0.0"
+      }
+    },
+    "imagemin-svgo": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-7.0.0.tgz",
+      "integrity": "sha512-+iGJFaPIMx8TjFW6zN+EkOhlqcemdL7F3N3Y0wODvV2kCUBuUtZK7DRZc1+Zfu4U2W/lTMUyx2G8YMOrZntIWg==",
+      "dev": true,
+      "requires": {
+        "is-svg": "^3.0.0",
+        "svgo": "^1.0.5"
+      }
+    },
+    "immer": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
+      "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      }
+    },
+    "import-lazy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+      "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-color-stop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+      "dev": true,
+      "requires": {
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-gif": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-gif/-/is-gif-3.0.0.tgz",
+      "integrity": "sha512-IqJ/jlbw5WJSNfwQ/lHEDXF8rxhRgF6ythk2oiEvhpG29F704eX9NO6TvPfMiq9DrbwgcEDnETYNcZDPewQoVw==",
+      "dev": true,
+      "requires": {
+        "file-type": "^10.4.0"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-jpg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-2.0.0.tgz",
+      "integrity": "sha1-LhmX+m6RZuqsAkLarkQ0A+TvHZc=",
+      "dev": true
+    },
+    "is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-png": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
+      "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-root": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
+      "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-svg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+      "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "^1.1.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
+    "is2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+      "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^2.1.0",
+        "is-url": "^1.2.2"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+    },
+    "jpegtran-bin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-4.0.0.tgz",
+      "integrity": "sha512-2cRl1ism+wJUoYAYFt6O/rLBfpXNWG2dUWbgcEkTt5WGMnqI46eEro8T4C5zGROxKRqyKpCBSdHPvt5UYCtxaQ==",
+      "dev": true,
+      "requires": {
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.0",
+        "logalot": "^2.0.0"
+      }
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "requires": {
+        "set-getter": "^0.1.0"
+      }
+    },
+    "list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "repeat-string": "^1.5.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "livereload-js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
+      "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "loader-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+      "dev": true
+    },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
+      "dev": true
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+      "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "logalot": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+      "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
+      "dev": true,
+      "requires": {
+        "figures": "^1.3.5",
+        "squeak": "^1.0.0"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "lpad-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
+      "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "indent-string": "^2.1.0",
+        "longest": "^1.0.0",
+        "meow": "^3.3.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=",
+      "dev": true
+    },
+    "markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.2",
+        "diacritics-map": "^0.1.0",
+        "gray-matter": "^2.1.0",
+        "lazy-cache": "^2.0.2",
+        "list-item": "^1.1.1",
+        "markdown-link": "^0.1.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "object.pick": "^1.2.0",
+        "remarkable": "^1.7.1",
+        "repeat-string": "^1.6.1",
+        "strip-color": "^0.1.0"
+      }
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "microevent.ts": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
+      "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.28.tgz",
+      "integrity": "sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "dev": true
+    },
+    "npm-conf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+      "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
+    "optipng-bin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-5.1.0.tgz",
+      "integrity": "sha512-9baoqZTNNmXQjq/PQTWEXbVV3AMO2sI/GaaqZJZ8SExfAzjijeAP7FEeT+TtyumSw7gr0PZtSUYB/Ke7iHQVKA==",
+      "dev": true,
+      "requires": {
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.0",
+        "logalot": "^2.0.0"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "os-filter-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-2.0.0.tgz",
+      "integrity": "sha512-uksVLsqG3pVdzzPvmAHpBK0wKxYItuzZr7SziusRPoz67tGV8rL1szZ6IdeUrbqLjGDwApBtN29eEE3IqGHOjg==",
+      "dev": true,
+      "requires": {
+        "arch": "^2.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "dev": true
+    },
+    "p-event": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
+      "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^1.1.1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-map-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+      "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
+    "p-pipe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+      "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+      "dev": true
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
+    "portfinder": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
+      "integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+      "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+      "dev": true,
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss": "^7.0.5",
+        "postcss-selector-parser": "^5.0.0-rc.4",
+        "postcss-value-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-colormin": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+          "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-convert-values": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
+      "dev": true,
+      "requires": {
+        "css-color-names": "0.0.4",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-minify-font-values": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-minify-params": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-normalize-display-values": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-positions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-repeat-style": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-string": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-timing-functions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-unicode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-whitespace": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+      "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^2.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+      "integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+      "dev": true,
+      "requires": {
+        "is-svg": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "react": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-dev-utils": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.3.tgz",
+      "integrity": "sha512-OyInhcwsvycQ3Zr2pQN+HV4gtRXrky5mJXIy4HnqrWa+mI624xfYfqGuC9dYbxp4Qq3YZzP8GSGQjv0AgNU15w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.5.5",
+        "address": "1.1.0",
+        "browserslist": "4.6.6",
+        "chalk": "2.4.2",
+        "cross-spawn": "6.0.5",
+        "detect-port-alt": "1.1.6",
+        "escape-string-regexp": "1.0.5",
+        "filesize": "3.6.1",
+        "find-up": "3.0.0",
+        "fork-ts-checker-webpack-plugin": "1.5.0",
+        "global-modules": "2.0.0",
+        "globby": "8.0.2",
+        "gzip-size": "5.1.1",
+        "immer": "1.10.0",
+        "inquirer": "6.5.0",
+        "is-root": "2.1.0",
+        "loader-utils": "1.2.3",
+        "open": "^6.3.0",
+        "pkg-up": "2.0.0",
+        "react-error-overlay": "^6.0.1",
+        "recursive-readdir": "2.2.2",
+        "shell-quote": "1.6.1",
+        "sockjs-client": "1.3.0",
+        "strip-ansi": "5.2.0",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
+      }
+    },
+    "react-error-overlay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
+      "integrity": "sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
+      "integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+      "dev": true,
+      "requires": {
+        "private": "^0.1.6"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp-tree": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.12.tgz",
+      "integrity": "sha512-TsXZ8+cv2uxMEkLfgwO0E068gsNMLfuYwMMhiUxf0Kw2Vcgzq93vgl6wIlIYuPmfMqMjfQ9zAporiozqCnwLuQ==",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+      "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "rgb-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
+      "dev": true
+    },
+    "rgba-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "scheduler": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "dev": true,
+      "requires": {
+        "commander": "~2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
+      }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "dev": true
+    },
+    "semver-truncate": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "set-getter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+      "dev": true,
+      "requires": {
+        "to-object-path": "^0.3.0"
+      }
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "sitemap": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-3.2.2.tgz",
+      "integrity": "sha512-TModL/WU4m2q/mQcrDgNANn0P4LwprM9MMvG4hu5zP4c6IIKs2YLTu6nXXnNr8ODW/WFtxKggiJ1EGn2W0GNmg==",
+      "dev": true,
+      "requires": {
+        "lodash.chunk": "^4.2.0",
+        "lodash.padstart": "^4.6.1",
+        "whatwg-url": "^7.0.0",
+        "xmlbuilder": "^13.0.0"
+      }
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+      "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "dev": true,
+      "requires": {
+        "sort-keys": "^1.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "squeak": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+      "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "console-stream": "^0.1.1",
+        "lpad-align": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
+      "dev": true
+    },
+    "strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "dev": true,
+      "requires": {
+        "is-natural-number": "^4.0.1"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "stylehacks": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+      "integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "svgo": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.33",
+        "csso": "^3.5.1",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      }
+    },
+    "tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "tcp-port-used": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
+      "integrity": "sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.0",
+        "is2": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "dev": true
+    },
+    "tempfile": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+      "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+      "dev": true,
+      "requires": {
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "tiny-lr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+      "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
+      "dev": true,
+      "requires": {
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+          "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        }
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
+    "toml": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "tree-node-cli": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/tree-node-cli/-/tree-node-cli-1.2.5.tgz",
+      "integrity": "sha512-Yhv4bfLa3WYdJLS4FkCj0h72duPGMUjC6Ld8eBlT9BA3CfjeQyHNBfgtzQvDrw1OkQva2JSpUyslZHuweCRtGQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.15.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "truncate-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/truncate-html/-/truncate-html-1.0.3.tgz",
+      "integrity": "sha512-1o1prdRv+iehXcGwn29YgXU17DotHkr+OK3ijVEG7FGMwHNG9RyobXwimw6djDvbIc24rhmz3tjNNvNESjkNkQ==",
+      "dev": true,
+      "requires": {
+        "@types/cheerio": "^0.22.8",
+        "cheerio": "0.22.0"
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "unbzip2-stream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vendors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+      "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "websocket-driver": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+      "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
+    },
+    "worker-rpc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
+      "integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
+      "dev": true,
+      "requires": {
+        "microevent.ts": "~0.1.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yamljs": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz",
+      "integrity": "sha1-SBzHwlynOvWfWR8MluPOVsdXpA8=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      }
+    },
+    "yargs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
+      "integrity": "sha1-6QDIclDsXNCA22AJ/j3WMVbx1/s=",
+      "dev": true,
+      "requires": {
+        "wordwrap": "0.0.2"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -3,12 +3,14 @@
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
     "build": "docusaurus-build",
+    "build-api-reference": "graphql-markdown --no-title --update-file=../docs/api-reference.md",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.11.1"
+    "docusaurus": "^1.11.1",
+    "graphql-markdown": "^5.0.1"
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -79,7 +79,8 @@
           "api-process/check-out",
           "api-process/product"
         ]
-      }
+      },
+      "api-reference"
     ],
     "Running your Saleor Server": [
       {


### PR DESCRIPTION
This PR adds API Reference section. The reference was generated with [graphql-markdown](https://github.com/exogen/graphql-markdown) tool. It's not perfect, as the entire reference sits in a single file, but I think it's a good starting point.

To update the reference use the following command:
`npm run build-api-reference <schema>`

Example with Saleor running locally on default port:

`npm run build-api-reference http://localhost:8000/graphql/` 