### PR TITLE
Add link to edit document on GitHub

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -81,6 +81,8 @@ const siteConfig = {
       "Segoe UI Symbol"
     ]
   },
+  
+  editUrl: "https://github.com/mirumee/saleor-docs/edit/master/docs/",
 
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
   copyright: `Copyright © ${new Date().getFullYear()} Your Name or Your Company Name`,


### PR DESCRIPTION
This tiny change encourages people to improve the page, and just usually in the docs there is a similar link.

![image](https://user-images.githubusercontent.com/4408379/66392072-862f5480-e9d7-11e9-814d-d2204e7c4562.png)
