### PR TITLE
Remove copy button outline in Firefox

### DIFF
--- a/website/static/css/code-block-copy-button.css
+++ b/website/static/css/code-block-copy-button.css
@@ -21,6 +21,10 @@ pre .copyCodeButton:focus {
   outline: 0;
 }
 
+pre .copyCodeButton::-moz-focus-inner {
+  border: none;
+}
+
 pre:hover .copyCodeButton {
   opacity: 1;
 }


### PR DESCRIPTION
As reported in  https://github.com/mirumee/saleor-docs/pull/55#issuecomment-539709428

сс @NyanKiyoshi