### PR TITLE
Add unified button style

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -4,6 +4,16 @@ body {
   font-family: $inter;
 }
 
+.button {
+  color: #525f7f;
+  border: 1px solid #525f7f;
+}
+
+.button:hover {
+  background: #edf5f8;
+  color: inherit;
+}
+
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }
 


### PR DESCRIPTION
Currently styles for buttons (edit button) with a green border  due the default theme style for Docusaurus. This PR overrides the default styles for the button to look like other buttons on docsite.

Before:

![image](https://user-images.githubusercontent.com/4408379/66597641-0c01fa00-eba8-11e9-9f5b-8abfb492c7c2.png)

After:

![image](https://user-images.githubusercontent.com/4408379/66597418-9f86fb00-eba7-11e9-8567-32c957cac755.png)
