### PR TITLE
Revert path to API docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -53,7 +53,7 @@ const siteConfig = {
       doc: "dashboard/before-you-start",
       label: "Saleor Dashboard Guide"
     },
-    { doc: "api/intro", label: "GraphQL API" },
+    { href: "/docs/next/api/intro", label: "GraphQL API" },
     {
       doc: "getting-started/intro",
       label: "Running your Saleor Server"


### PR DESCRIPTION
Reverts last change of path to API section. It doesn't work with docs for 2.8 where this section was not available.