### PR TITLE
Document API for customer accounts

### DIFF
--- a/docs/developer.mdx
+++ b/docs/developer.mdx
@@ -37,6 +37,8 @@ import CardGrid from "@site/components/CardGrid"
 
 [**Checkout** The checkout flow.](developer/checkout.mdx)
 
+[**Users** Creating and managing customer accounts.](developer/users.mdx)
+
 [**Metadata** Store additional information about items.](developer/metadata.mdx)
 
 [**Extending** Add custom logic to a Saleor store.](developer/extending.mdx)

--- a/docs/developer/users.mdx
+++ b/docs/developer/users.mdx
@@ -12,7 +12,7 @@ This guide describes how to use the Saleor GraphQL API to register a new account
 Depending on the configuration of your Saleor backend instance, registering a new customer account may be a single-step operation or it may require email confirmation to activate the account (see [`ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL`](developer/configuration.mdx#enable_account_confirmation_by_email)).
 
 :::info
-When a new account is created, Saleor checks if there are any orders in the system that were placed using the new account's email and are not assigned to any other user. If there are any, they're matched with the new account.
+When a new account is created, Saleor checks if there are any orders in the system that were placed using the new account's email and are not assigned to any other user. If there are, they're matched with the new account.
 :::
 
 Let's see first how to register a new account without email confirmation.

--- a/docs/developer/users.mdx
+++ b/docs/developer/users.mdx
@@ -246,8 +246,130 @@ This mutation requires the [authorization header with a valid JWT](developer/aut
 
 ## Changing email
 
-...
+Changing an email of existing user accounts is a two-step operation. First, you need to call the `requestEmailChange` mutation.
+
+The mutation takes the following input fields:
+
+- `newEmail` - the new email address to set for the account.
+- `password` - the current user's password.
+- `redirectUrl` - path to a view where the user should be redirected to confirm the new email address.
+
+```graphql
+mutation {
+  requestEmailChange(
+    newEmail: "new-address@example.com"
+    password: "secret"
+    redirectUrl: "http://localhost:3000/confirm-email/"
+  ) {
+    accountErrors {
+      field
+      code
+    }
+    user {
+      email
+    }
+  }
+}
+```
+
+If there are no errors, the mutation sends an email to the `newEmail` address with a link to confirm the operation. In this example, we also return the `email` of the current user. As you can see in the response below, the email isn't yet updated.
+
+```json
+{
+  "data": {
+    "requestEmailChange": {
+      "accountErrors": [],
+      "user": {
+        "email": "admin@example.com"
+      }
+    }
+  }
+}
+```
+
+The confirmation links an additional query-string parameter `token` which is required to confirm the operation, e.g.:
+
+```
+http://localhost:3000/confirm-email/?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1ODYxNzY5OTQsIm9sZF9lbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwibmV3X2VtYWlsIjoibmV3LWFkZHJlc3NAZXhhbXBsZS5jb20iLCJ1c2VyX3BrIjoyMX0.aGAo28Ss_zOn_TwAzLCXdY1xENpf_-uw2khORoodKR8
+```
+
+To confirm the operation, we need to use the `confirmEmailChange` mutation, which accepts the following input:
+
+- `token` - a unique token that was included in the link in the email.
+
+```graphql
+mutation {
+  confirmEmailChange(
+    token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1ODYxNzY5OTQsIm9sZF9lbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwibmV3X2VtYWlsIjoibmV3LWFkZHJlc3NAZXhhbXBsZS5jb20iLCJ1c2VyX3BrIjoyMX0.aGAo28Ss_zOn_TwAzLCXdY1xENpf_-uw2khORoodKR8"
+  ) {
+    accountErrors {
+      field
+      code
+    }
+    user {
+      email
+    }
+  }
+}
+```
+
+If the token is valid the email should be now updated:
+
+```
+{
+  "data": {
+    "confirmEmailChange": {
+      "accountErrors": [],
+      "user": {
+        "email": "new-address@example.com"
+      }
+    }
+  }
+}
+```
+
+Both mutation require the [authorization header with a valid JWT](developer/auth/jwt.mdx).
 
 ## Deleting an account
 
-...
+If you wish to remove your own customer account, you can do so by using two mutations. First, you need to request to delete your account with the `accountRequestDeletion` mutation. This mutation takes the following input:
+
+- `redirectUrl` - path to a view where the user can confirm deleting the account.
+
+```graphql
+mutation {
+  accountRequestDeletion(redirectUrl: "http://localhost:3000/confirm-delete/") {
+    accountErrors {
+      field
+      message
+      code
+    }
+  }
+}
+```
+
+As a result, ff there are no errors, the user receives an email with a link to confirm deleting their account. The link includes the `token` query parameter that is required in the second mutation:
+
+```
+http://localhost:3000/confirm-delete/?token=5ff-b5818345d8b64331b068
+```
+
+To confirm deleting the account, use the `accountDelete` mutation which accepts the following input:
+
+- `token` - a unique token that was included in the link in the email.
+
+```graphql
+mutation {
+  accountDelete(token: "5ff-b5818345d8b64331b068") {
+    accountErrors {
+      field
+      message
+      code
+    }
+  }
+}
+```
+
+As a result, the account is now deleted.
+
+Both mutations require the [authorization header with a valid JWT](developer/auth/jwt.mdx).

--- a/docs/developer/users.mdx
+++ b/docs/developer/users.mdx
@@ -1,21 +1,24 @@
 ---
-title: Users
+title: Manage Account as a Customer
 sidebar_label: Users
 ---
 
 ## Introduction
 
-This guide describes how to use the Saleor GraphQL API to register a new account as a customer and do the most common account management operations.
+This guide describes how to use the Saleor GraphQL API to register a new account as a customer and do common account management operations.
 
 ## Creating a new customer account
 
-Depending on the configuration of your Saleor backend instance, registering a new customer account may be a simple, single-step operation or it may require email confirmation to activate the account (see [`ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL`](developer/configuration.mdx#enable_account_confirmation_by_email)).
+Depending on the configuration of your Saleor backend instance, registering a new customer account may be a single-step operation or it may require email confirmation to activate the account (see [`ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL`](developer/configuration.mdx#enable_account_confirmation_by_email)).
 
 Let's see first how to register a new account without email confirmation.
 
 ### Registration without email confirmation
 
-To create a new customer account, use the `accountRegister` mutation.
+To create a new customer account, use the `accountRegister` mutation. The mutation takes the following input fields:
+
+- `email` - user's email address.
+- `password` - user's password.
 
 ```graphql
 mutation {
@@ -24,22 +27,15 @@ mutation {
   ) {
     accountErrors {
       field
-      message
       code
     }
     user {
-      id
       email
       isActive
     }
   }
 }
 ```
-
-The mutation takes the following input fields:
-
-- `email` - the user's email address.
-- `password` - the user's password.
 
 As a result, we get data of the newly created user:
 
@@ -49,7 +45,6 @@ As a result, we get data of the newly created user:
     "accountRegister": {
       "accountErrors": [],
       "user": {
-        "id": "VXNlcjo1MA==",
         "email": "customer@example.com",
         "isActive": true
       }
@@ -58,9 +53,9 @@ As a result, we get data of the newly created user:
 }
 ```
 
-The `isActive` flag informs that the account is active.
+The `isActive` flag informs that the account is active and the user can log in to their account.
 
-Examples above include `accountErrors` field, which may return any data-level errors when, for some reason, the account couldn't be created. Here is a response that you would get if an account with the email provided in the mutation already exists:
+Examples above include `accountErrors` field, which may return any [data-level errors](developer/error-handling.mdx#data-level-errors). Here is a response that would be returned if there is already account registered for the given email:
 
 ```json
 {
@@ -69,7 +64,6 @@ Examples above include `accountErrors` field, which may return any data-level er
       "accountErrors": [
         {
           "field": "email",
-          "message": "User with this email already exists.",
           "code": "UNIQUE"
         }
       ],
@@ -81,7 +75,94 @@ Examples above include `accountErrors` field, which may return any data-level er
 
 ### Registration with email confirmation
 
-...
+Registering an account with email confirmation consists of two steps and it requires you to have a storefront view, where users will be redirected to confirm their email. First, you need to use the `accountRegister` mutation, which will create an inactive account and send an email with the confirmation link.
+
+The mutation takes the following input fields:
+
+- `email` - user's email address.
+- `password` - user's password.
+- `redirectUrl` - path to a view where the user should be redirected to confirm their email
+
+This example assumes that you're running the storefront locally with the default settings (running on port `3000`):
+
+```graphql
+mutation {
+  accountRegister(
+    input: {
+      email: "customer@example.com"
+      password: "secret"
+      redirectUrl: "http://localhost:3000/account-confirm/"
+    }
+  ) {
+    accountErrors {
+      field
+      code
+    }
+    user {
+      email
+      isActive
+    }
+  }
+}
+```
+
+As a result, we get data of the newly created, but yet inactive user:
+
+```json
+{
+  "data": {
+    "accountRegister": {
+      "accountErrors": [],
+      "user": {
+        "email": "customer@example.com",
+        "isActive": false
+      }
+    }
+  }
+}
+```
+
+At the same time the user `customer@example.com` should receive an email with a confirmation link based on provided `redirectUrl` path, for example:
+
+```
+http://localhost:3000/account-confirm/?email=customer%40example.com&token=5fc-9f2116f96bdafd612cf4
+```
+
+The link contains two query parameters - `email` and `token` - which are required to proceed with the second mutation, `confirmAccount`:
+
+```graphql
+mutation {
+  confirmAccount(
+    email: "customer@example.com"
+    token: "5fc-9f2116f96bdafd612cf4"
+  ) {
+    accountErrors {
+      field
+      code
+    }
+    user {
+      email
+      isActive
+    }
+  }
+}
+```
+
+If the token is valid, the user will be successfully activated:
+
+```json
+{
+  "data": {
+    "confirmAccount": {
+      "accountErrors": [],
+      "user": {
+        "email": "customer@example.com",
+        "isActive": true
+      }
+    }
+  }
+}
+```
 
 ## Password reset
 

--- a/docs/developer/users.mdx
+++ b/docs/developer/users.mdx
@@ -1,0 +1,92 @@
+---
+title: Users
+sidebar_label: Users
+---
+
+## Introduction
+
+This guide describes how to use the Saleor GraphQL API to register a new account as a customer and do the most common account management operations.
+
+## Creating a new customer account
+
+Depending on the configuration of your Saleor backend instance, registering a new customer account may be a simple, single-step operation or it may require email confirmation to activate the account (see [`ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL`](developer/configuration.mdx#enable_account_confirmation_by_email)).
+
+Let's see first how to register a new account without email confirmation.
+
+### Registration without email confirmation
+
+To create a new customer account, use the `accountRegister` mutation.
+
+```graphql
+mutation {
+  accountRegister(
+    input: { email: "customer@example.com", password: "secret" }
+  ) {
+    accountErrors {
+      field
+      message
+      code
+    }
+    user {
+      id
+      email
+      isActive
+    }
+  }
+}
+```
+
+The mutation takes the following input fields:
+
+- `email` - the user's email address.
+- `password` - the user's password.
+
+As a result, we get data of the newly created user:
+
+```json
+{
+  "data": {
+    "accountRegister": {
+      "accountErrors": [],
+      "user": {
+        "id": "VXNlcjo1MA==",
+        "email": "customer@example.com",
+        "isActive": true
+      }
+    }
+  }
+}
+```
+
+The `isActive` flag informs that the account is active.
+
+Examples above include `accountErrors` field, which may return any data-level errors when, for some reason, the account couldn't be created. Here is a response that you would get if an account with the email provided in the mutation already exists:
+
+```json
+{
+  "data": {
+    "accountRegister": {
+      "accountErrors": [
+        {
+          "field": "email",
+          "message": "User with this email already exists.",
+          "code": "UNIQUE"
+        }
+      ],
+      "user": null
+    }
+  }
+}
+```
+
+### Registration with email confirmation
+
+...
+
+## Password reset
+
+...
+
+## Email change
+
+...

--- a/docs/developer/users.mdx
+++ b/docs/developer/users.mdx
@@ -11,6 +11,10 @@ This guide describes how to use the Saleor GraphQL API to register a new account
 
 Depending on the configuration of your Saleor backend instance, registering a new customer account may be a single-step operation or it may require email confirmation to activate the account (see [`ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL`](developer/configuration.mdx#enable_account_confirmation_by_email)).
 
+:::info
+When a new account is created, Saleor checks if there are any orders in the system that were placed using the new account's email and are not assigned to any other user. If there are any, they're matched with the new account.
+:::
+
 Let's see first how to register a new account without email confirmation.
 
 ### Registration without email confirmation
@@ -164,10 +168,86 @@ If the token is valid, the user will be successfully activated:
 }
 ```
 
-## Password reset
+## Resetting password
+
+Resetting the password is a two-step operation. First, you need to call a mutation to send an email with a unique link to reset the password.
+
+The mutation takes the following input fields:
+
+- `email` - user's email address.
+- `redirectUrl` - path to a view where the user should be redirected to reset the password.
+
+```graphql
+mutation {
+  requestPasswordReset(
+    email: "customer@example.com"
+    redirectUrl: "http://localhost:3000/reset-password/"
+  ) {
+    accountErrors {
+      field
+      code
+    }
+  }
+}
+```
+
+As a result, if there are no errors in the response, the system sends an email to `customer@example.com` with a link to provide a new password, for example:
+
+```
+http://localhost:3000/reset-password/?email=customer%40example.com&token=5fc-9f2116f96bdafd612cf4
+```
+
+The link contains two query parameters - `email` and `token` - which are required to proceed with the second mutation, `setPassword`.
+
+The mutation takes the following input fields:
+
+- `token` - a unique token that was included in the link in the email.
+- `email` - user's email address.
+- `password` - the new password.
+
+```graphql
+mutation {
+  setPassword(
+    token: "5fc-9f2116f96bdafd612cf4"
+    email: "customer@example.com"
+    password: "new-secret"
+  ) {
+    accountErrors {
+      field
+      code
+    }
+  }
+}
+```
+
+If there are no errors in the response, the password is successfully changed.
+
+## Changing password
+
+If you wish to change your password as an authenticated customer, use the `passwordChange` mutation. The mutation takes the following input fields:
+
+- `oldPassword` - the current user's password.
+- `newPassword` - the new password.
+
+```graphql
+mutation {
+  passwordChange(oldPassword: "secret", newPassword: "new-secret") {
+    accountErrors {
+      field
+      code
+    }
+  }
+}
+```
+
+If no errors were returned, the password is now successfully changed.
+
+This mutation requires the [authorization header with a valid JWT](developer/auth/jwt.mdx).
+
+## Changing email
 
 ...
 
-## Email change
+## Deleting an account
 
 ...

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -79,15 +79,14 @@
       {
         "type": "category",
         "label": "Authentication",
-        "items": [
-          "developer/auth/jwt"
-        ]
+        "items": ["developer/auth/jwt"]
       },
       "developer/pagination",
       "developer/error-handling",
       "developer/configuration",
       "developer/products",
       "developer/checkout",
+      "developer/users",
       "developer/metadata",
       {
         "type": "category",


### PR DESCRIPTION
Add documentation for customer accounts API:
- [x] account registration (simple)
- [x] account registration with email confirmation
- [x] resetting the password
- [x] changing the email

Part of #112 changes.