### PR TITLE
Work around Mermaid's rerendering bug

### DIFF
--- a/website/components/Chart/index.jsx
+++ b/website/components/Chart/index.jsx
@@ -1,15 +1,14 @@
-import React, { useEffect, useMemo, useState } from "react";
-import mermaid from "mermaid";
+import React, { useEffect, useState } from "react";
+import { mermaidAPI } from "mermaid";
 
 import "./styles.css";
 
-mermaid.initialize({
+mermaidAPI.initialize({
   startOnLoad: false,
   theme: null,
 });
 
 const Chart = ({ definition }) => {
-  const id = useMemo(() => `mermaid-${Date.now().toString()}`, [definition]);
   const [fontsLoaded, setFontsLoaded] = useState(
     typeof window !== "undefined" && document.fonts.status === "loaded"
   );
@@ -19,11 +18,11 @@ const Chart = ({ definition }) => {
     if (typeof window !== "undefined" && !fontsLoaded) {
       document.fonts.ready.then(() => setFontsLoaded(true));
     }
-  }, [id]);
+  });
 
   useEffect(() => {
-    mermaid.render(id, definition, (svg) => setSvg(svg));
-  }, [id, fontsLoaded]);
+    mermaidAPI.render(`mermaid-${Date.now().toString()}`, definition, (svg) => setSvg(svg));
+  }, [fontsLoaded]);
 
   return (
     <div className="mermaid" dangerouslySetInnerHTML={{ __html: svg }}></div>


### PR DESCRIPTION
Fixes an exception during reloading of pages that contain charts (for example the Extending page).

Mermaid uses D3 internally but it serialized and deserializes its output, losing data binding in the process so when an existing node is encountered by D3 is trips over the lack of a `__data__` attribute. By using a unique ID each time we rerender we prevent D3 from ever seeing the existing structure.