### PR TITLE
Adding Querystring settings to doc

### DIFF
--- a/docs/developer/running-saleor/s3.mdx
+++ b/docs/developer/running-saleor/s3.mdx
@@ -16,6 +16,8 @@ This integration allows you to delegate storing such files to [Amazon’s S3 ser
 | `AWS_MEDIA_CUSTOM_DOMAIN`  | The custom domain to use for the media bucket.  |
 | `AWS_STORAGE_BUCKET_NAME`  | The S3 bucket name to use for static files.     |
 | `AWS_STATIC_CUSTOM_DOMAIN` | The custom domain to use for the static bucket. |
+| `AWS_QUERYSTRING_AUTH`     | Enabling query parameter authentication from generated URLs. |
+| `AWS_QUERYSTRING_EXPIRE`   | The number of seconds that a generated URL is valid for | 
 
 ## Serving media files from an S3 bucket
 


### PR DESCRIPTION
I just added the two environment variables AWS_QUERYSTRING_AUTH and AWS_QUERYSTRING_EXPIRE to the docs.