### PR TITLE
Add FAQ for no cairo library error

### DIFF
--- a/docs/developer/community/faq.mdx
+++ b/docs/developer/community/faq.mdx
@@ -37,6 +37,19 @@ We’ve recently introduced a new repository: [saleor-platform](https://github.c
 
 See [Extending Saleor](developer/extending/plugins.mdx).
 
+## I cannot run Saleor server. I receive an error: ‘OSError: no library called "cairo" was found, no library called "libcairo-2" was found‘. What should I do?
+
+You need to install `cairo` and probably `pango` library too.
+For macOS just enter `brew install pango cairo` in your terminal.
+In case of Linux and Windows system follow instructions from [cairo](https://www.cairographics.org/download/) and
+from [pango](https://pango.gnome.org/Download) websites.
+
+``` note
+If you get this error you probably running Seleor outside docker containers.
+We recommend using Saleor Platform where this error shouldn't appear.
+```
+
+
 ## How to set up the environment variables?
 
 See [Configuration](developer/running-saleor/configuration.mdx#setting-environment-variables).


### PR DESCRIPTION
Add FAQ for `OSError: no library called "cairo" was found, no library called "libcairo-2" was found` error.