### PR TITLE
Update checkoutCreate mutation for 2.9 and 2.10

### DIFF
--- a/website/versioned_docs/version-2.10/developer/checkout.mdx
+++ b/website/versioned_docs/version-2.10/developer/checkout.mdx
@@ -60,7 +60,7 @@ mutation {
         streetAddress1: "1470  Pinewood Avenue"
         city: "Michigan"
         postalCode: "49855"
-        country: "US"
+        country: US
         countryArea: "MI"
       }
       billingAddress: {
@@ -69,7 +69,7 @@ mutation {
         streetAddress1: "1470  Pinewood Avenue"
         city: "Michigan"
         postalCode: "49855"
-        country: "US"
+        country: US
         countryArea: "MI"
       }
     }

--- a/website/versioned_docs/version-2.9.0/api-process/check-out.md
+++ b/website/versioned_docs/version-2.9.0/api-process/check-out.md
@@ -69,7 +69,7 @@ mutation {
         streetAddress1: "1470  Pinewood Avenue"
         city: "Michigan"
         postalCode: "49855"
-        country: "US"
+        country: US
         countryArea: "MI"
       }
       billingAddress: {
@@ -78,7 +78,7 @@ mutation {
         streetAddress1: "1470  Pinewood Avenue"
         city: "Michigan"
         postalCode: "49855"
-        country: "US"
+        country: US
         countryArea: "MI"
       }
     }


### PR DESCRIPTION
There is a small mistake in `checkoutCreate` mutation, which was fixed for master (#147), but not for 2.9 and 2.10. 
This PR fixing the mistake on 2.9 and 2.10.
