### PR TITLE
Add missing sort fields to docs

### DIFF
--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -77,7 +77,7 @@ In `products` you can also sort the results using two `sortBy` arguments:
   - `NAME`: sort products by name.
   - `PRICE`: sort products by base price.
   - `PUBLICATION_DATE`: sort products by publication date.
-  - `PUBLISHED`: sort products by publish status.
+  - `PUBLISHED`: sort products by publication status.
   - `TYPE`: sort products by product type.
 - `direction`: The direction for sorting items:
   - `ASC`: sort ascending.

--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -76,7 +76,9 @@ In `products` you can also sort the results using two `sortBy` arguments:
   - `PRICE`: sort products by base price.
   - `MINIMAL_PRICE`: sort products by minimal variant price.
   - `DATE`: sort products by last update.
-  - `PUBLISHED`: sort products by publication date.
+  - `TYPE`: sort products by product type.
+  - `PUBLISHED`: sort products by publish status.
+  - `PUBLICATION_DATE`: sort products by publication date.
 - `direction`: The direction for sorting items:
   - `ASC`: sort ascending.
   - `DESC`: sort descending.

--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -76,6 +76,7 @@ In `products` you can also sort the results using two `sortBy` arguments:
   - `PRICE`: sort products by base price.
   - `MINIMAL_PRICE`: sort products by minimal variant price.
   - `DATE`: sort products by last update.
+  - `PUBLISHED`: sort products by publication date.
 - `direction`: The direction for sorting items:
   - `ASC`: sort ascending.
   - `DESC`: sort descending.

--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -72,13 +72,13 @@ Here is an example query that looks for the first 3 products containing the term
 In `products` you can also sort the results using two `sortBy` arguments:
 
 - `field`: the field to use for sorting the results from several predefined choices:
+  - `DATE`: sort products by last update.
+  - `MINIMAL_PRICE`: sort products by minimal variant price.
   - `NAME`: sort products by name.
   - `PRICE`: sort products by base price.
-  - `MINIMAL_PRICE`: sort products by minimal variant price.
-  - `DATE`: sort products by last update.
-  - `TYPE`: sort products by product type.
-  - `PUBLISHED`: sort products by publish status.
   - `PUBLICATION_DATE`: sort products by publication date.
+  - `PUBLISHED`: sort products by publish status.
+  - `TYPE`: sort products by product type.
 - `direction`: The direction for sorting items:
   - `ASC`: sort ascending.
   - `DESC`: sort descending.


### PR DESCRIPTION
Add to sort section information about fields:
- `TYPE`
- `PUBLISHED`
- `PUBLICATION_DATE `