### PR TITLE
Add missing step in custom errors

### DIFF
--- a/docs/developer/extending/api/errors.mdx
+++ b/docs/developer/extending/api/errors.mdx
@@ -24,7 +24,19 @@ class ExampleErrorCode(Enum):
     UNIQUE = "unique"
 ```
 
-### Step 2: Add error codes to GraphQL enums
+### Step 2: Add error codes to Django forms ValidationError mapper
+
+To allow parse form errors to proper the error code, add error class to `SALEOR_ERROR_CODE_ENUMS` in `saleor/graphql/core/utils/error_codes.py`.
+
+```python
+SALEOR_ERROR_CODE_ENUMS = [
+    ExampleErrorCode,
+    AccountErrorCode,
+    AppErrorCode,
+    ...
+```
+
+### Step 3: Add error codes to GraphQL enums
 
 To add error codes to GraphQL enums you should add an entry in `saleor/graphql/core/enums.py`.
 
@@ -32,7 +44,7 @@ To add error codes to GraphQL enums you should add an entry in `saleor/graphql/c
 ExampleErrorCode = graphene.Enum.from_enum(error_codes.ExampleErrorCode)
 ```
 
-### Step 3: Create error class
+### Step 4: Create error class
 
 To allow usage error code in mutation, add error class in `saleor/graphql/core/types/common.py`.
 
@@ -41,7 +53,7 @@ class ExampleError(Error):
     code = ExampleErrorCode(description="The error code.", required=True)
 ```
 
-### Step 4: Assign error codes to mutation
+### Step 5: Assign error codes to mutation
 
 To use an new error codes in mutation, add `error_type_class` and `error_type_field` to `Meta` inside mutation.
 

--- a/docs/developer/extending/api/errors.mdx
+++ b/docs/developer/extending/api/errors.mdx
@@ -26,7 +26,7 @@ class ExampleErrorCode(Enum):
 
 ### Step 2: Add error codes to Django forms ValidationError mapper
 
-To allow parse form errors to proper the error code, add error class to `SALEOR_ERROR_CODE_ENUMS` in `saleor/graphql/core/utils/error_codes.py`.
+To allow parse form errors to the proper error code, add the error class to the  `SALEOR_ERROR_CODE_ENUMS` in `saleor/graphql/core/utils/error_codes.py`.
 
 ```python
 SALEOR_ERROR_CODE_ENUMS = [

--- a/docs/developer/extending/api/errors.mdx
+++ b/docs/developer/extending/api/errors.mdx
@@ -24,9 +24,9 @@ class ExampleErrorCode(Enum):
     UNIQUE = "unique"
 ```
 
-### Step 2: Add error codes to Django forms ValidationError mapper
+### Step 2: Register newly created error code enum
 
-To allow parse form errors to the proper error code, add the error class to the  `SALEOR_ERROR_CODE_ENUMS` in `saleor/graphql/core/utils/error_codes.py`.
+To differentiate between built-in Django's error codes and the custom ones, add the error class to the  `SALEOR_ERROR_CODE_ENUMS` list in `saleor/graphql/core/utils/error_codes.py`.
 
 ```python
 SALEOR_ERROR_CODE_ENUMS = [


### PR DESCRIPTION
In documentation related to extending errors, we have a missing step. 