### PR TITLE
Update S3 CORS instructions

### DIFF
--- a/docs/developer/running-saleor/s3.mdx
+++ b/docs/developer/running-saleor/s3.mdx
@@ -37,7 +37,7 @@ Custom domain will allow you to use your CloudFront distribution or the public d
 
 ## Cross-Origin Resource Sharing
 
-You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). Paste the code below in your S3 Bucket’s permissions tab, under the [CORS section](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
+You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.), under the permissions tab. An example configuration that allows all hosts and headers is as below:
 
 ```json
 [
@@ -57,3 +57,5 @@ You need to configure your S3 bucket to allow cross-origin requests for some fil
   }
 ]
 ```
+
+Refer to the [AWS CORS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) for more details.

--- a/docs/developer/running-saleor/s3.mdx
+++ b/docs/developer/running-saleor/s3.mdx
@@ -37,22 +37,8 @@ Custom domain will allow you to use your CloudFront distribution or the public d
 
 ## Cross-Origin Resource Sharing
 
-You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). Follow the below instructions in your S3 Bucket’s permissions tab, under the [CORS section](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
+You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). Paste the code below in your S3 Bucket’s permissions tab, under the [CORS section](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <CORSRule>
-    <AllowedOrigin>*</AllowedOrigin>
-    <AllowedMethod>GET</AllowedMethod>
-    <AllowedMethod>HEAD</AllowedMethod>
-    <MaxAgeSeconds>3000</MaxAgeSeconds>
-    <AllowedHeader>*</AllowedHeader>
-  </CORSRule>
-</CORSConfiguration>
-```
-
-If you're using the new S3 dashboard:
 ```json
 [
   {

--- a/docs/developer/running-saleor/s3.mdx
+++ b/docs/developer/running-saleor/s3.mdx
@@ -37,7 +37,7 @@ Custom domain will allow you to use your CloudFront distribution or the public d
 
 ## Cross-Origin Resource Sharing
 
-You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). Follow the below instructions in your S3 Bucket’s permissions tab, under the [CORS section](https://cloud.google.com/storage/docs/xml-api/put-bucket-cors).
+You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). Follow the below instructions in your S3 Bucket’s permissions tab, under the [CORS section](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -50,4 +50,24 @@ You need to configure your S3 bucket to allow cross-origin requests for some fil
     <AllowedHeader>*</AllowedHeader>
   </CORSRule>
 </CORSConfiguration>
+```
+
+If you're using the new S3 dashboard:
+```json
+[
+  {
+    "AllowedHeaders": [
+      "*"
+    ],
+    "AllowedMethods": [
+      "GET",
+      "HEAD"
+    ],
+    "AllowedOrigins": [
+      "*"
+    ],
+    "ExposeHeaders": [],
+    "MaxAgeSeconds": 3000
+  }
+]
 ```


### PR DESCRIPTION
- Update the link to CORS instructions from GCP to AWS docs
- Add instructions for CORS configuration when using the new S3 console (only allows JSON config)