### PR TITLE
Fix Apps command typo

### DIFF
--- a/docs/developer/extending/apps.mdx
+++ b/docs/developer/extending/apps.mdx
@@ -168,7 +168,7 @@ Arguments:
 > python manage.py create_app "Order App" \
 >    --permission MANAGE_USERS \
 >    --permission MANAGE_ORDERS \
->    --target_url https://your-order-app/your-register-endpoint/
+>    --target-url https://your-order-app/your-register-endpoint/
 > ```
 
 


### PR DESCRIPTION
Docs used `_` instead of `-`