### PR TITLE
Describe address parameter in pricing API

### DIFF
--- a/docs/developer/products.mdx
+++ b/docs/developer/products.mdx
@@ -337,6 +337,64 @@ type Money {
 }
 ```
 
+See [Prices](api-conventions/prices.mdx) for more information about money types.
+
+### Fetching prices with tax rates specific to a country
+
+When using Saleor with tax plugins such as Vatlayer, you can fetch prices including taxes specific to a country. To do that, pass the `address` parameter in the `pricing` field including a country code, for which the tax should be calculated. The `address` parameter is available in `Product.pricing` and `ProductVariant.pricing` fields.
+
+In the example below we fetch a price of a product variant for Poland, where the standard VAT rate is 23%:
+
+```graphql {3}
+{
+  productVariant(id: "UHJvZHVjdFZhcmlhbnQ6MjAz", channel: "default-channel") {
+    pricing(address: {country: PL}) {
+      price {
+        net {
+          amount
+        }
+        gross {
+          amount
+        }
+        tax {
+          amount
+        }
+      }
+    }
+  }
+}
+```
+
+Result:
+
+```
+{
+  "data": {
+    "productVariant": {
+      "pricing": {
+        "price": {
+          "net": {
+            "amount": 5
+          },
+          "gross": {
+            "amount": 6.15
+          },
+          "tax": {
+            "amount": 1.15
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The tax equals 1.15 which is 23% of the net price. Gross price is the sum of net price and the tax.
+
+:::note
+Note: The `address` parameter is optional. If it's not provided, Saleor will use the default country code configured in the backend settings (see [DEFAULT_COUNTRY](running-saleor/configuration.mdx#default_country)).
+:::
+
 ## Images
 
 The `Product` type contains two fields that refer to its images:


### PR DESCRIPTION
Document the recently added `address` param for pricing fields.