### PR TITLE
Add S3 ACL description

### DIFF
--- a/docs/developer/running-saleor/s3.mdx
+++ b/docs/developer/running-saleor/s3.mdx
@@ -11,13 +11,14 @@ This integration allows you to delegate storing such files to [Amazon’s S3 ser
 | Variable Name              | Description                                     |
 |----------------------------|-------------------------------------------------|
 | `AWS_ACCESS_KEY_ID`        | Your AWS access key.                            |
-| `AWS_SECRET_ACCESS_KEY`    | Your AWS secret access key.                     |
+| `AWS_DEFAULT_ACL`          | Default [Access Control List](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html) to uploaded files. |
 | `AWS_MEDIA_BUCKET_NAME`    | The S3 bucket name to use for media files.      |
 | `AWS_MEDIA_CUSTOM_DOMAIN`  | The custom domain to use for the media bucket.  |
-| `AWS_STORAGE_BUCKET_NAME`  | The S3 bucket name to use for static files.     |
-| `AWS_STATIC_CUSTOM_DOMAIN` | The custom domain to use for the static bucket. |
 | `AWS_QUERYSTRING_AUTH`     | Enabling query parameter authentication from generated URLs. |
 | `AWS_QUERYSTRING_EXPIRE`   | The number of seconds that a generated URL is valid for | 
+| `AWS_SECRET_ACCESS_KEY`    | Your AWS secret access key.                     |
+| `AWS_STATIC_CUSTOM_DOMAIN` | The custom domain to use for the static bucket. |
+| `AWS_STORAGE_BUCKET_NAME`  | The S3 bucket name to use for static files.     |
 
 ## Serving media files from an S3 bucket
 
@@ -26,6 +27,8 @@ This integration allows you to delegate storing such files to [Amazon’s S3 ser
 If you want to use S3 to store and serve media files, you need to configure at least the bucket name (see table above).
 
 Custom domain will allow you to use your CloudFront distribution or the public domain of your S3 bucket's static hosting.
+
+If you are experiencing problems accessing uploaded files, ensure that permissions are correctly configured (`AWS_DEFAULT_ACL` environment variable).
 
 ## Serving static files from an S3 bucket
 

--- a/docs/developer/running-saleor/s3.mdx
+++ b/docs/developer/running-saleor/s3.mdx
@@ -11,11 +11,11 @@ This integration allows you to delegate storing such files to [Amazon’s S3 ser
 | Variable Name              | Description                                     |
 |----------------------------|-------------------------------------------------|
 | `AWS_ACCESS_KEY_ID`        | Your AWS access key.                            |
-| `AWS_DEFAULT_ACL`          | Default [Access Control List](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html) to uploaded files. |
+| `AWS_DEFAULT_ACL`          | [Access Control List](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html) for uploaded files. By default, none is assigned. |
 | `AWS_MEDIA_BUCKET_NAME`    | The S3 bucket name to use for media files.      |
 | `AWS_MEDIA_CUSTOM_DOMAIN`  | The custom domain to use for the media bucket.  |
 | `AWS_QUERYSTRING_AUTH`     | Enabling query parameter authentication from generated URLs. |
-| `AWS_QUERYSTRING_EXPIRE`   | The number of seconds that a generated URL is valid for | 
+| `AWS_QUERYSTRING_EXPIRE`   | The number of seconds that a generated URL is valid for. | 
 | `AWS_SECRET_ACCESS_KEY`    | Your AWS secret access key.                     |
 | `AWS_STATIC_CUSTOM_DOMAIN` | The custom domain to use for the static bucket. |
 | `AWS_STORAGE_BUCKET_NAME`  | The S3 bucket name to use for static files.     |


### PR DESCRIPTION
Fixes #34

Misconfiguring access permissions is a common issue with deployments. Added short description and linked AWS docs.