### PR TITLE
Direct community to the GitHub Discussions

### DIFF
--- a/docs/developer/community/support.mdx
+++ b/docs/developer/community/support.mdx
@@ -2,9 +2,9 @@
 title: Support
 ---
 
-## Spectrum
+## GitHub Discussions
 
-Join our [Spectrum community](https://spectrum.chat/saleor) to ask questions and propose features.
+Join our [GitHub Discussions](https://github.com/mirumee/saleor/discussions) to ask questions and propose features.
 
 ## Stack Overflow
 

--- a/website/versioned_docs/version-2.11/developer/community/support.mdx
+++ b/website/versioned_docs/version-2.11/developer/community/support.mdx
@@ -2,9 +2,9 @@
 title: Support
 ---
 
-## Spectrum
+## GitHub Discussions
 
-Join our [Spectrum community](https://spectrum.chat/saleor) to ask questions and propose features.
+Join our [GitHub Discussions](https://github.com/mirumee/saleor/discussions) to ask questions and propose features.
 
 ## Stack Overflow
 


### PR DESCRIPTION
Since spectrum is going into maintenance mode, we should direct all users to the Discussions