### PR TITLE
Corrections in s3.mdx

### DIFF
--- a/website/versioned_docs/version-2.11/developer/running-saleor/s3.mdx
+++ b/website/versioned_docs/version-2.11/developer/running-saleor/s3.mdx
@@ -37,7 +37,7 @@ Custom domain will allow you to use your CloudFront distribution or the public d
 
 ## Cross-Origin Resource Sharing
 
-You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). Follow the below instructions in your S3 Bucket’s permissions tab, under the [CORS section](https://cloud.google.com/storage/docs/xml-api/put-bucket-cors).
+You need to configure your S3 bucket to allow cross-origin requests for some files to be properly served (SVG files, Javascript files, etc.). To do this, set the below instructions in your S3 Bucket’s permissions tab, under the [CORS section](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Changed typo and wording to be consistent with the GCP section. The link to the AWS documentation was pointing to GCP, changed it to AWS docs.