### PR TITLE
Add headers section to indicate deprecated headers

### DIFF
--- a/docs/developer/extending/apps/asynchronous-webhooks.mdx
+++ b/docs/developer/extending/apps/asynchronous-webhooks.mdx
@@ -33,11 +33,26 @@ Webhook payloads are sent in POST requests.
 
 All webhooks with `targetUrl`, where the scheme is HTTP(S) will use this protocol.
 
-Saleor calculates the HMAC sha256 header - `X-Saleor-Signature` based on `secretKey` and the payload.
+Saleor calculates the HMAC sha256 header - `Saleor-Signature` based on `secretKey` and the payload.
 
 If a successful response has not been received in the case of temporary service unavailability, it will retry its request after a delay in time.
 
 While HTTPS webhooks are a familiar concept and may seem easy to implement, make sure your endpoint can handle the same level of concurrency that you expect from the monitored events. Saleor Cloud will do its best to deliver webhooks in real-time, which could mean more traffic than your servers can handle. Because of this and the possibility of losing events when the destination server is down, we recommend using a queue like Google Cloud Pub/Sub or AWS SQS (see below).
+
+### Headers
+During HTTPS requests there are several headers included:
+- Saleor-Event - defines event which is assigned to the webhook
+- Saleor-Domain - defines saleor domain
+- Saleor-Signature - defines signature to indicate that the request is authorized
+
+:::warning
+In Saleor 4.0 all `X-Saleor-` headers will be deprecated and replaced with headers without `X-` prefix.
+
+Deprecated headers list:
+- X-Saleor-Event -> Saleor-Event
+- X-Saleor-Domain -> Saleor-Domain
+- X-Saleor-Signature -> Saleor-Signature
+:::
 
 ### Google Cloud Pub/Sub
 

--- a/docs/developer/extending/apps/key-concepts.mdx
+++ b/docs/developer/extending/apps/key-concepts.mdx
@@ -50,4 +50,4 @@ Authorization: Bearer <app-token>
 
 ## Verifying incoming payload - the secret key
 
-To ensure that the incoming webhook payload is from the known host, Saleor adds `X-Saleor-Signature` header to the request. It's created using payload and `secretKey`, specified by the app during webhook registration. [Read more](developer/extending/apps/asynchronous-webhooks.mdx#https).
+To ensure that the incoming webhook payload is from the known host, Saleor adds `Saleor-Signature` header to the request. It's created using payload and `secretKey`, specified by the app during webhook registration. [Read more](developer/extending/apps/asynchronous-webhooks.mdx#https).

--- a/docs/developer/extending/apps/synchronous-webhooks.mdx
+++ b/docs/developer/extending/apps/synchronous-webhooks.mdx
@@ -116,7 +116,7 @@ Each item on the list should have the following fields:
 
 ### Register webhooks for payment actions
 
-To subscribe to particular payment events (such as capture or authorization), you can have multiple webhooks with separate URLs for each action or a single webhook that handles all events (each webhook has an `X-Saleor-Event` header that contains the type of event).
+To subscribe to particular payment events (such as capture or authorization), you can have multiple webhooks with separate URLs for each action or a single webhook that handles all events (each webhook has an `Saleor-Event` header that contains the type of event).
 
 List of payment events: 
 

--- a/versioned_docs/version-2.11/developer/extending/apps.mdx
+++ b/versioned_docs/version-2.11/developer/extending/apps.mdx
@@ -105,7 +105,7 @@ Webhook payloads are sent in POST requests.
 
 All webhooks with `targetUrl`, where the scheme is HTTP(S) will use this protocol.
 
-Saleor calculates the HMAC sha256 header - `X-Saleor-Signature` based on `secretKey` and the payload
+Saleor calculates the HMAC sha256 header - `Saleor-Signature` based on `secretKey` and the payload
 
 
 ##### Google Cloud Pub/Sub


### PR DESCRIPTION
Added headers section with information about `X-` headers deprecation,
Headers list with replacements:
* X-Saleor-Event -> Saleor-Event
* X-Saleor-Domain -> Saleor-Domain
* X-Saleor-Signature -> Saleor-Signature
* X-Saleor-HMAC-SHA256 -> Saleor-HMAC-SHA256

[Linked task for version `4.0` ](https://app.clickup.com/t/1jku0m9)

